### PR TITLE
Make `libgit2-sys` depend on `openssl-sys` for `aarch64-unknown-linux-gnu` triple as well

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -27,6 +27,8 @@ openssl-sys = "0.2.0"
 openssl-sys = "0.2.0"
 [target.x86_64-unknown-linux-gnu.dependencies]
 openssl-sys = "0.2.0"
+[target.aarch64-unknown-linux-gnu.dependencies]
+openssl-sys = "0.2.0"
 [target.i686-unknown-freebsd.dependencies]
 openssl-sys = "0.2.0"
 [target.x86_64-unknown-freebsd.dependencies]


### PR DESCRIPTION
As rust-lang/rust#19790 is hopefully landing soon, but rust-lang/cargo#1007 is still open, it would be good to add this dependency. (Now, cargo builds need manual touchups after pulls.)

(Similar to https://github.com/carllerche/curl-rust/pull/48)