### PR TITLE
Remove features globs and phase from libgit2-sys

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1,4 +1,3 @@
-#![feature(globs, phase)]
 #![allow(non_camel_case_types, missing_copy_implementations)]
 
 extern crate libc;


### PR DESCRIPTION
These features have been removed:

```
Compiling libgit2-sys v0.1.5 (https://github.com/alexcrichton/git2-rs#b22ff68b)
lib.rs:1:12: 1:17 warning: feature has been added to Rust, directive not necessary
lib.rs:1 #![feature(globs, phase)]
                    ^~~~~
lib.rs:1:19: 1:24 error: feature has been removed
lib.rs:1 #![feature(globs, phase)]
                           ^~~~~
```