### PR TITLE
Add function revparse_ext to Repository impl

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1198,6 +1198,10 @@ extern {
     pub fn git_revparse_single(out: *mut *mut git_object,
                                repo: *mut git_repository,
                                spec: *const c_char) -> c_int;
+    pub fn git_revparse_ext(object_out: *mut *mut git_object,
+                            reference_out: *mut *mut git_reference,
+                            repo: *mut git_repository,
+                            spec: *const c_char) -> c_int;
 
     // object
     pub fn git_object_dup(dest: *mut *mut git_object,


### PR DESCRIPTION
This PR adds Repository::revparse_ext. This function is a thin proxy for [https://libgit2.github.com/libgit2/#HEAD/group/repository/git_revparse_ext](git_revparse_ext).