### PR TITLE
[RDY] Bind the blame API

### DIFF
--- a/examples/blame.rs
+++ b/examples/blame.rs
@@ -1,0 +1,105 @@
+/*
+ * libgit2 "blame" example - shows how to use the blame API
+ *
+ * Written by the libgit2 contributors
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+extern crate git2;
+extern crate docopt;
+extern crate rustc_serialize;
+
+use docopt::Docopt;
+use git2::{Repository, BlameOptions};
+use std::path::Path;
+use std::io::{BufReader, BufRead};
+
+#[derive(RustcDecodable)] #[allow(non_snake_case)]
+struct Args {
+    arg_path: String,
+    arg_spec: Option<String>,
+    flag_M: bool,
+    flag_C: bool,
+    flag_F: bool,
+}
+
+fn run(args: &Args) -> Result<(), git2::Error> {
+    let repo = try!(Repository::open("."));
+    let path = Path::new(&args.arg_path[..]);
+
+    // Prepare our blame options
+    let mut opts = BlameOptions::new();
+    opts.track_copies_same_commit_moves(args.flag_M)
+        .track_copies_same_commit_copies(args.flag_C)
+        .first_parent(args.flag_F);
+
+    let mut commit_id = "HEAD".to_string();
+
+    // Parse spec
+    if let Some(spec) = args.arg_spec.as_ref() {
+
+        let revspec = try!(repo.revparse(spec));
+
+        let (oldest, newest) = if revspec.mode().contains(git2::REVPARSE_SINGLE) {
+            (None, revspec.from())
+        } else if revspec.mode().contains(git2::REVPARSE_RANGE) {
+            (revspec.from(), revspec.to())
+        } else {
+            (None, None)
+        };
+
+        if let Some(commit) = oldest {
+            opts.oldest_commit(commit.id());
+        }
+
+        if let Some(commit) = newest {
+            opts.newest_commit(commit.id());
+            if !commit.id().is_zero() {
+                commit_id = format!("{}", commit.id())
+            }
+        }
+
+    }
+
+    let spec = format!("{}:{}", commit_id, path.display());
+    let blame = try!(repo.blame_file(path, Some(&mut opts)));
+    let object = try!(repo.revparse_single(&spec[..]));
+    let blob = try!(repo.find_blob(object.id()));
+    let reader = BufReader::new(blob.content());
+
+    for (i, line) in reader.lines().enumerate() {
+        if let (Ok(line), Some(hunk)) = (line, blame.get_line(i+1)) {
+            let sig = hunk.final_signature();
+            println!("{} {} <{}> {}", hunk.final_commit_id(),
+                     String::from_utf8_lossy(sig.name_bytes()),
+                     String::from_utf8_lossy(sig.email_bytes()), line);
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    const USAGE: &'static str = "
+usage: blame [options] [<spec>] <path>
+
+Options:
+    -M                  find line moves within and across files
+    -C                  find line copies within and across files
+    -F                  follow only the first parent commits
+";
+
+    let args = Docopt::new(USAGE).and_then(|d| d.decode())
+                                 .unwrap_or_else(|e| e.exit());
+    match run(&args) {
+        Ok(()) => {}
+        Err(e) => println!("error: {}", e),
+    }
+}

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -1,0 +1,301 @@
+use std::marker;
+use {raw, Repository, Oid, signature, Signature};
+use util::{self, Binding};
+use std::path::Path;
+use std::ops::Range;
+use std::mem;
+
+/// Opaque structure to hold blame results.
+pub struct Blame<'repo> {
+    raw: *mut raw::git_blame,
+    _marker: marker::PhantomData<&'repo Repository>,
+}
+
+/// Structure that represents a blame hunk.
+pub struct BlameHunk<'blame> {
+    raw: *mut raw::git_blame_hunk,
+    _marker: marker::PhantomData<&'blame raw::git_blame>,
+}
+
+/// Blame options
+pub struct BlameOptions {
+    raw: raw::git_blame_options,
+}
+
+/// An iterator over the hunks in a blame.
+pub struct BlameIter<'blame> {
+    range: Range<usize>,
+    blame: &'blame Blame<'blame>,
+}
+
+impl<'repo> Blame<'repo> {
+
+    /// Gets the number of hunks that exist in the blame structure.
+    pub fn len(&self) -> usize {
+        unsafe { raw::git_blame_get_hunk_count(self.raw) as usize }
+    }
+
+    /// Gets the blame hunk at the given index.
+    pub fn get_index(&self, index: usize) -> Option<BlameHunk> {
+        unsafe {
+            let ptr = raw::git_blame_get_hunk_byindex(self.raw(), index as u32);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(BlameHunk::from_raw_const(ptr))
+            }
+        }
+    }
+
+    /// Gets the hunk that relates to the given line number in the newest
+    /// commit.
+    pub fn get_line(&self, lineno: usize) -> Option<BlameHunk> {
+        unsafe {
+            let ptr = raw::git_blame_get_hunk_byline(self.raw(), lineno as u32);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(BlameHunk::from_raw_const(ptr))
+            }
+        }
+    }
+
+    /// Returns an iterator over the hunks in this blame.
+    pub fn iter(&self) -> BlameIter {
+        BlameIter { range: 0..self.len(), blame: self }
+    }
+
+}
+
+impl<'blame> BlameHunk<'blame> {
+
+    unsafe fn from_raw_const(raw: *const raw::git_blame_hunk)
+                                 -> BlameHunk<'blame> {
+        BlameHunk {
+            raw: raw as *mut raw::git_blame_hunk,
+            _marker: marker::PhantomData,
+        }
+    }
+
+    /// Returns OID of the commit where this line was last changed
+    pub fn final_commit_id(&self) -> Oid {
+        unsafe { Oid::from_raw(&(*self.raw).final_commit_id) }
+    }
+
+    /// Returns signature of the commit.
+    pub fn final_signature(&self) -> Signature {
+        unsafe { signature::from_raw_const(self, (*self.raw).final_signature) }
+    }
+
+    /// Returns line number where this hunk begins.
+    ///
+    /// Note that the start line is counting from 1.
+    pub fn final_start_line(&self) -> usize {
+        unsafe { (*self.raw).final_start_line_number as usize }
+    }
+
+    /// Returns the OID of the commit where this hunk was found.
+    ///
+    /// This will usually be the same as `final_commit_id`,
+    /// except when `BlameOptions::track_copies_any_commit_copies` has been
+    /// turned on
+    pub fn orig_commit_id(&self) -> Oid {
+        unsafe { Oid::from_raw(&(*self.raw).orig_commit_id) }
+    }
+
+    /// Returns signature of the commit.
+    pub fn orig_signature(&self) -> Signature {
+        unsafe { signature::from_raw_const(self, (*self.raw).orig_signature) }
+    }
+
+    /// Returns line number where this hunk begins.
+    ///
+    /// Note that the start line is counting from 1.
+    pub fn orig_start_line(&self) -> usize {
+        unsafe { (*self.raw).orig_start_line_number as usize }
+    }
+
+    /// Returns path to the file where this hunk originated.
+    ///
+    /// Note: `None` could be returned for non-unicode paths on Widnows.
+    pub fn path(&self) -> Option<&Path> {
+        unsafe {
+            if let Some(bytes) = ::opt_bytes(self, (*self.raw).orig_path) {
+                Some(util::bytes2path(bytes))
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Tests whether this hunk has been tracked to a boundary commit
+    /// (the root, or the commit specified in git_blame_options.oldest_commit).
+    pub fn is_boundary(&self) -> bool {
+        unsafe { (*self.raw).boundary == 1 }
+    }
+
+    /// Returns number of lines in this hunk.
+    pub fn lines_in_hunk(&self) -> usize {
+        unsafe { (*self.raw).lines_in_hunk as usize }
+    }
+}
+
+impl BlameOptions {
+
+    /// Initialize options
+    pub fn new() -> BlameOptions {
+        unsafe {
+            let mut raw: raw::git_blame_options = mem::zeroed();
+            assert_eq!(
+                raw::git_blame_init_options(&mut raw,
+                                            raw::GIT_BLAME_OPTIONS_VERSION)
+            , 0);
+
+            Binding::from_raw(&raw as *const _ as *mut _)
+        }
+    }
+
+    fn flag(&mut self, opt: u32, val: bool) -> &mut BlameOptions {
+        if val {
+            self.raw.flags |= opt;
+        } else {
+            self.raw.flags &= !opt;
+        }
+        self
+    }
+
+    /// Track lines that have moved within a file.
+    pub fn track_copies_same_file(&mut self, opt: bool) -> &mut BlameOptions {
+        self.flag(raw::GIT_BLAME_TRACK_COPIES_SAME_FILE, opt)
+    }
+
+    /// Track lines that have moved across files in the same commit.
+    pub fn track_copies_same_commit_moves(&mut self, opt: bool) -> &mut BlameOptions {
+        self.flag(raw::GIT_BLAME_TRACK_COPIES_SAME_COMMIT_MOVES, opt)
+    }
+
+    /// Track lines that have been copied from another file that exists
+    /// in the same commit.
+    pub fn track_copies_same_commit_copies(&mut self, opt: bool) -> &mut BlameOptions {
+        self.flag(raw::GIT_BLAME_TRACK_COPIES_SAME_COMMIT_COPIES, opt)
+    }
+
+    /// Track lines that have been copied from another file that exists
+    /// in any commit.
+    pub fn track_copies_any_commit_copies(&mut self, opt: bool) -> &mut BlameOptions {
+        self.flag(raw::GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES, opt)
+    }
+
+    /// Restrict the search of commits to those reachable following only
+    /// the first parents.
+    pub fn first_parent(&mut self, opt: bool) -> &mut BlameOptions {
+        self.flag(raw::GIT_BLAME_FIRST_PARENT, opt)
+    }
+
+    /// Setter for the id of the newest commit to consider.
+    pub fn newest_commit(&mut self, id: Oid) -> &mut BlameOptions {
+        unsafe { self.raw.newest_commit = *id.raw(); }
+        self
+    }
+
+    /// Setter for the id of the oldest commit to consider.
+    pub fn oldest_commit(&mut self, id: Oid) -> &mut BlameOptions {
+        unsafe { self.raw.oldest_commit = *id.raw(); }
+        self
+    }
+
+}
+
+impl<'repo> Binding for Blame<'repo> {
+    type Raw = *mut raw::git_blame;
+
+    unsafe fn from_raw(raw: *mut raw::git_blame) -> Blame<'repo> {
+        Blame { raw: raw, _marker: marker::PhantomData }
+    }
+
+    fn raw(&self) -> *mut raw::git_blame { self.raw }
+}
+
+impl<'repo> Drop for Blame<'repo> {
+    fn drop(&mut self) {
+        unsafe { raw::git_blame_free(self.raw) }
+    }
+}
+
+impl<'blame> Binding for BlameHunk<'blame> {
+    type Raw = *mut raw::git_blame_hunk;
+
+    unsafe fn from_raw(raw: *mut raw::git_blame_hunk) -> BlameHunk<'blame> {
+        BlameHunk { raw: raw, _marker: marker::PhantomData }
+    }
+
+    fn raw(&self) -> *mut raw::git_blame_hunk { self.raw }
+}
+
+impl Binding for BlameOptions {
+    type Raw = *mut raw::git_blame_options;
+
+    unsafe fn from_raw(opts: *mut raw::git_blame_options) -> BlameOptions {
+        BlameOptions { raw: *opts }
+    }
+
+    fn raw(&self) -> *mut raw::git_blame_options { &self.raw as *const _ as *mut _ }
+}
+
+impl<'blame> Iterator for BlameIter<'blame> {
+    type Item = BlameHunk<'blame>;
+    fn next(&mut self) -> Option<BlameHunk<'blame>> {
+        self.range.next().and_then(|i| self.blame.get_index(i))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+}
+
+impl<'blame> DoubleEndedIterator for BlameIter<'blame> {
+    fn next_back(&mut self) -> Option<BlameHunk<'blame>> {
+        self.range.next_back().and_then(|i| self.blame.get_index(i))
+    }
+}
+
+impl<'blame> ExactSizeIterator for BlameIter<'blame> {}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::path::Path;
+
+    #[test]
+    fn smoke() {
+        let (_td, repo) = ::test::repo_init();
+        let mut index = repo.index().unwrap();
+
+        let root = repo.path().parent().unwrap();
+        fs::create_dir(&root.join("foo")).unwrap();
+        File::create(&root.join("foo/bar")).unwrap();
+        index.add_path(Path::new("foo/bar")).unwrap();
+
+        let id = index.write_tree().unwrap();
+        let tree = repo.find_tree(id).unwrap();
+        let sig = repo.signature().unwrap();
+        let id = repo.refname_to_id("HEAD").unwrap();
+        let parent = repo.find_commit(id).unwrap();
+        let commit = repo.commit(Some("HEAD"), &sig, &sig, "commit",
+                                 &tree, &[&parent]).unwrap();
+
+        let blame = repo.blame_file(Path::new("foo/bar"), None).unwrap();
+
+        assert_eq!(blame.len(), 1);
+        assert_eq!(blame.iter().count(), 1);
+
+        let hunk = blame.get_index(0).unwrap();
+        assert_eq!(hunk.final_commit_id(), commit);
+        assert_eq!(hunk.final_signature().name(), sig.name());
+        assert_eq!(hunk.final_signature().email(), sig.email());
+        assert_eq!(hunk.final_start_line(), 1);
+        assert_eq!(hunk.path(), Some(Path::new("foo/bar")));
+        assert_eq!(hunk.lines_in_hunk(), 0);
+        assert!(!hunk.is_boundary())
+    }
+
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use std::fmt;
 use std::str;
 use std::sync::{Once, ONCE_INIT};
 
+pub use blame::{Blame, BlameHunk, BlameIter, BlameOptions};
 pub use blob::Blob;
 pub use branch::{Branch, Branches};
 pub use buf::Buf;
@@ -289,6 +290,7 @@ pub mod cert;
 pub mod string_array;
 pub mod transport;
 
+mod blame;
 mod blob;
 mod branch;
 mod buf;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -6,7 +6,7 @@ use std::str;
 use libc::{c_int, c_char, size_t, c_void, c_uint};
 
 use {raw, Revspec, Error, init, Object, RepositoryState, Remote, Buf};
-use {ResetType, Signature, Reference, References, Submodule};
+use {ResetType, Signature, Reference, References, Submodule, Blame, BlameOptions};
 use {Branches, BranchType, Index, Config, Oid, Blob, Branch, Commit, Tree};
 use {ObjectType, Tag, Note, Notes, StatusOptions, Statuses, Status, Revwalk};
 use {RevparseMode, RepositoryInitMode, Reflog, IntoCString};
@@ -1084,6 +1084,22 @@ impl Repository {
         let mut raw = 0 as *mut raw::git_revwalk;
         unsafe {
             try_call!(raw::git_revwalk_new(&mut raw, self.raw()));
+            Ok(Binding::from_raw(raw))
+        }
+    }
+
+    #[allow(unused_variables)]
+    /// Get the blame for a single file.
+    pub fn blame_file(&self, path: &Path, opts: Option<&mut BlameOptions>)
+                      -> Result<Blame, Error> {
+        let path = try!(path.into_c_string());
+        let mut raw = 0 as *mut raw::git_blame;
+
+        unsafe {
+            try_call!(raw::git_blame_file(&mut raw,
+                                          self.raw(),
+                                          path,
+                                          opts.map(|s| s.raw())));
             Ok(Binding::from_raw(raw))
         }
     }


### PR DESCRIPTION
Looks like I'm finished.
- [x] bind `git_blame_hunk`
- [x] bind `git_blame_get_hunk_byindex`
- [x] bind `git_blame_get_hunk_byline`
- [x] think of how to get raw_data for hunks
- [x] write example of use

`git_blame_buffer` is too complicated for my understanding :)