### PR TITLE
Implement peeling for references

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1391,6 +1391,9 @@ extern {
     pub fn git_reference_name_to_id(out: *mut git_oid,
                                     repo: *mut git_repository,
                                     name: *const c_char) -> c_int;
+    pub fn git_reference_peel(out: *mut *mut git_object,
+                              r: *const git_reference,
+                              otype: git_otype) -> c_int;
     pub fn git_reference_rename(new_ref: *mut *mut git_reference,
                                 r: *mut git_reference,
                                 new_name: *const c_char,


### PR DESCRIPTION
When a command is interested in e.g. a tree-ish, calling the reference's
peel function is a lot more convenient than going through the objects by
hand.