### PR TITLE
Add a few more merge-related bindings

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1476,6 +1476,10 @@ extern {
     pub fn git_reference_symbolic_target(r: *const git_reference) -> *const c_char;
     pub fn git_reference_target(r: *const git_reference) -> *const git_oid;
     pub fn git_reference_target_peel(r: *const git_reference) -> *const git_oid;
+    pub fn git_reference_set_target(out: *mut *mut git_reference,
+                                    r: *mut git_reference,
+                                    id: *const git_oid,
+                                    log_message: *const c_char) -> c_int;
     pub fn git_reference_type(r: *const git_reference) -> git_ref_t;
     pub fn git_reference_iterator_new(out: *mut *mut git_reference_iterator,
                                       repo: *mut git_repository) -> c_int;
@@ -1949,6 +1953,7 @@ extern {
                      len: size_t,
                      merge_opts: *const git_merge_options,
                      checkout_opts: *const git_checkout_options) -> c_int;
+    pub fn git_repository_state_cleanup(repo: *mut git_repository) -> c_int;
 
     // notes
     pub fn git_note_author(note: *const git_note) -> *const git_signature;

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1953,6 +1953,11 @@ extern {
                      len: size_t,
                      merge_opts: *const git_merge_options,
                      checkout_opts: *const git_checkout_options) -> c_int;
+    pub fn git_merge_commits(out: *mut *mut git_index,
+                             repo: *mut git_repository,
+                             our_commit: *const git_commit,
+                             their_commit: *const git_commit,
+                             opts: *const git_merge_options) -> c_int;
     pub fn git_repository_state_cleanup(repo: *mut git_repository) -> c_int;
 
     // notes

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -179,6 +179,19 @@ impl<'repo> Reference<'repo> {
         }
     }
 
+    /// Conditionally create a new reference with the same name as the given
+    /// reference but a different OID target. The reference must be a direct
+    /// reference, otherwise this will fail.
+    pub fn set_target(&mut self, id: Oid, msg: &str) -> Result<Reference<'repo>, Error> {
+        let mut raw = 0 as *mut raw::git_reference;
+        let msg = try!(CString::new(msg));
+        unsafe {
+            try_call!(raw::git_reference_set_target(&mut raw, self.raw,
+                                                    id.raw(), msg));
+            Ok(Binding::from_raw(raw))
+        }
+    }
+
 }
 
 impl<'repo> PartialOrd for Reference<'repo> {

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -182,6 +182,9 @@ impl<'repo> Reference<'repo> {
     /// Conditionally create a new reference with the same name as the given
     /// reference but a different OID target. The reference must be a direct
     /// reference, otherwise this will fail.
+    ///
+    /// The new reference will be written to disk, overwriting the given
+    /// reference.
     pub fn set_target(&mut self, id: Oid, msg: &str) -> Result<Reference<'repo>, Error> {
         let mut raw = 0 as *mut raw::git_reference;
         let msg = try!(CString::new(msg));

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1041,6 +1041,15 @@ impl Repository {
         Ok(())
     }
 
+    /// Remove all the metadata associated with an ongoing command like merge,
+    /// revert, cherry-pick, etc. For example: MERGE_HEAD, MERGE_MSG, etc.
+    pub fn cleanup_state(&self) -> Result<(), Error> {
+        unsafe {
+            try_call!(raw::git_repository_state_cleanup(self.raw));
+        }
+        Ok(())
+    }
+
     /// Add a note for an object
     ///
     /// The `notes_ref` argument is the canonical name of the reference to use,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1041,6 +1041,23 @@ impl Repository {
         Ok(())
     }
 
+    /// Merge two commits, producing a git_index that reflects the result of
+    /// the merge. The index may be written as-is to the working directory or
+    /// checked out. If the index is to be converted to a tree, the caller
+    /// should resolve any conflicts that arose as part of the merge.
+    pub fn merge_commits(&self, our_commit: &Commit, their_commit: &Commit,
+                         opts: Option<&MergeOptions>) -> Result<Index, Error> {
+         let mut raw = 0 as *mut raw::git_index;
+        unsafe {
+            try_call!(raw::git_merge_commits(&mut raw, self.raw,
+                                             our_commit.raw(),
+                                             their_commit.raw(),
+                                             opts.map_or(0 as *const raw::git_merge_options,
+                                                         |o| o.raw())));
+            Ok(Binding::from_raw(raw))
+        }
+    }
+
     /// Remove all the metadata associated with an ongoing command like merge,
     /// revert, cherry-pick, etc. For example: MERGE_HEAD, MERGE_MSG, etc.
     pub fn cleanup_state(&self) -> Result<(), Error> {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1041,10 +1041,16 @@ impl Repository {
         Ok(())
     }
 
-    /// Merge two commits, producing a git_index that reflects the result of
+    /// Merge two commits, producing an index that reflects the result of
     /// the merge. The index may be written as-is to the working directory or
     /// checked out. If the index is to be converted to a tree, the caller
     /// should resolve any conflicts that arose as part of the merge.
+    ///
+    /// The merge performed uses the first common ancestor, unlike the
+    /// git-merge-recursive strategy, which may produce an artificial common
+    /// ancestor tree when there are multiple ancestors.
+    ///
+    /// The returned index must be freed explicitly with git_index_free.
     pub fn merge_commits(&self, our_commit: &Commit, their_commit: &Commit,
                          opts: Option<&MergeOptions>) -> Result<Index, Error> {
          let mut raw = 0 as *mut raw::git_index;


### PR DESCRIPTION
Adding repo.merge_commits() here, repo.cleanup_state(), as well as ref.set_target()