### PR TITLE
Fix build on OS X

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -20,6 +20,10 @@ libc = "0.1"
 [build-dependencies]
 pkg-config = "0.3"
 
+[target.i686-apple-darwin.dependencies]
+libz-sys = "0.1.0"
+[target.x86_64-apple-darwin.dependencies]
+libz-sys = "0.1.0"
 [target.i686-unknown-linux-gnu.dependencies]
 openssl-sys = "0.6.0"
 libz-sys = "0.1.0"

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1172,7 +1172,7 @@ pub struct git_smart_subtransport_definition {
 }
 
 /// Initialize openssl for the libgit2 library
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 pub fn openssl_init() {
     if !cfg!(target_os = "linux") && !cfg!(target_os = "freebsd") { return }
 
@@ -1290,7 +1290,7 @@ pub fn openssl_init() {
     openssl::probe::init_ssl_cert_env_vars();
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "macos"))]
 pub fn openssl_init() {}
 
 extern {


### PR DESCRIPTION
The recent update to libgit2 v0.23 removed all dependencies from on OS
X. While there is no OpenSSL dependency anymore, the libz-sys crate is
still needed by libgit2-sys/lib.rs.

Even then, libgit2-sys/lib.rs tries to run an OpenSSL function to get
set up with the certs, which fails to compile as we don't have this on
OS X.

Change the conditional compilation flags to make OS X the same as
Windows, an completely OpenSSL-free zone.