### PR TITLE
build: always check for libgit2 via pkg-config first

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -20,6 +20,7 @@ libz-sys = "0.1.0"
 
 [build-dependencies]
 pkg-config = "0.3"
+semver = "0.1"
 cmake = "0.1.2"
 
 [target.i686-unknown-linux-gnu.dependencies]

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -1,4 +1,5 @@
 extern crate pkg_config;
+extern crate semver;
 extern crate cmake;
 
 use std::env;
@@ -12,8 +13,12 @@ fn main() {
     register_dep("OPENSSL");
     let has_pkgconfig = Command::new("pkg-config").output().is_ok();
 
-    if env::var("LIBGIT2_SYS_USE_PKG_CONFIG").is_ok() {
-        if pkg_config::find_library("libgit2").is_ok() {
+    // Try to find if a compatible ligbit2 is available, via pkg-config
+    let git2_pc = pkg_config::find_library("libgit2");
+    if git2_pc.is_ok() {
+        let req_vers = semver::VersionReq::parse("0.23").unwrap();
+        let git2_vers = semver::Version::parse(git2_pc.unwrap().version.as_ref());
+        if git2_vers.is_ok() && req_vers.matches(&git2_vers.unwrap()) {
             return
         }
     }


### PR DESCRIPTION
I'd like to have libgit2-sys automatically pull the right lib via pkg-config, if a compatible version is available. I'm not sure why #68 introduced a new ENV key instead of explicitly checking for the available version, so this PR just does it.