### PR TITLE
[WIP] Remove unneeded FFI calls

### DIFF
--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::cmp::Ordering;
 use std::hash::{Hasher, Hash};
+use std::str;
 use libc;
 
 use {raw, Error};

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::cmp::Ordering;
 use std::hash::{Hasher, Hash};
-use std::str;
 use libc;
 
 use {raw, Error};
@@ -49,7 +48,7 @@ impl Oid {
 
     /// Test if this OID is all zeros.
     pub fn is_zero(&self) -> bool {
-        unsafe { raw::git_oid_iszero(&self.raw) == 1 }
+        self.raw.id == [0; 20]
     }
 }
 
@@ -71,13 +70,11 @@ impl fmt::Debug for Oid {
 impl fmt::Display for Oid {
     /// Hex-encode this Oid into a formatter.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut dst = [0u8; raw::GIT_OID_HEXSZ + 1];
-        unsafe {
-            raw::git_oid_tostr(dst.as_mut_ptr() as *mut libc::c_char,
-                               dst.len() as libc::size_t, &self.raw);
+        for byte in &self.raw.id {
+            try!(write!(f, "{:x}", *byte))
         }
-        let s = &dst[..dst.iter().position(|&a| a == 0).unwrap()];
-        str::from_utf8(s).unwrap().fmt(f)
+
+        Ok(())
     }
 }
 
@@ -95,7 +92,7 @@ impl str::FromStr for Oid {
 
 impl PartialEq for Oid {
     fn eq(&self, other: &Oid) -> bool {
-        unsafe { raw::git_oid_equal(&self.raw, &other.raw) != 0 }
+        self.raw.id == other.raw.id
     }
 }
 impl Eq for Oid {}
@@ -108,11 +105,7 @@ impl PartialOrd for Oid {
 
 impl Ord for Oid {
     fn cmp(&self, other: &Oid) -> Ordering {
-        match unsafe { raw::git_oid_cmp(&self.raw, &other.raw) } {
-            0 => Ordering::Equal,
-            n if n < 0 => Ordering::Less,
-            _ => Ordering::Greater,
-        }
+        Ord::cmp(&self.raw.id, &other.raw.id)
     }
 }
 


### PR DESCRIPTION
Reduce FFI calls. Some of them can be made in safe, idiomatic Rust without FFI calls. It can be also step forward to make `git2-rs` independent from `libgit2-sys`.