### PR TITLE
`Diff.foreach` support

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2292,9 +2292,9 @@ extern {
                                       version: c_uint) -> c_int;
     pub fn git_diff_foreach(diff: *mut git_diff,
                             file_cb: git_diff_file_cb,
-                            binary_cb: git_diff_binary_cb,
-                            hunk_cb: git_diff_hunk_cb,
-                            line_cb: git_diff_line_cb,
+                            binary_cb: Option<git_diff_binary_cb>,
+                            hunk_cb: Option<git_diff_hunk_cb>,
+                            line_cb: Option<git_diff_line_cb>,
                             payload: *mut c_void) -> c_int;
     pub fn git_diff_free(diff: *mut git_diff);
     pub fn git_diff_get_delta(diff: *const git_diff,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1188,12 +1188,13 @@ mod tests {
         }
 
         #[test]
-        #[ignore]
         fn file_and_hunk() {
             let path = Path::new("foo");
             let (td, repo) = ::test::repo_init();
             t!(t!(File::create(&td.path().join(path))).write_all(b"bar"));
-            let diff = t!(repo.diff_tree_to_workdir(None, Some(DiffOptions::new().include_untracked(true))));
+            let mut index = t!(repo.index());
+            t!(index.add_path(path));
+            let diff = t!(repo.diff_tree_to_index(None, Some(&index), Some(DiffOptions::new().include_untracked(true))));
             let mut new_lines = 0;
             t!(diff.foreach(
                 &mut |_file, _progress| { true },

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -76,14 +76,14 @@ pub struct DiffStats {
 
 /// Structure describing the binary contents of a diff.
 pub struct DiffBinary<'diff> {
-  raw: *const raw::git_diff_binary,
-  _marker: marker::PhantomData<&'diff raw::git_diff_binary>,
+    raw: *const raw::git_diff_binary,
+    _marker: marker::PhantomData<&'diff raw::git_diff_binary>,
 }
 
 /// The contents of one of the files in a binary diff.
 pub struct DiffBinaryFile<'diff> {
-  raw: *const raw::git_diff_binary_file,
-  _marker: marker::PhantomData<&'diff raw::git_diff_binary_file>,
+    raw: *const raw::git_diff_binary_file,
+    _marker: marker::PhantomData<&'diff raw::git_diff_binary_file>,
 }
 
 type PrintCb<'a> = FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a;
@@ -94,10 +94,10 @@ pub type HunkCb<'a> = FnMut(DiffDelta, DiffHunk) -> bool + 'a;
 pub type LineCb<'a> = FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a;
 
 struct ForeachCallbacks<'a, 'b: 'a, 'c, 'd: 'c, 'e, 'f: 'e, 'g, 'h: 'g> {
-  file: &'a mut FileCb<'b>,
-  binary: Option<&'c mut BinaryCb<'d>>,
-  hunk: Option<&'e mut HunkCb<'f>>,
-  line: Option<&'g mut LineCb<'h>>,
+    file: &'a mut FileCb<'b>,
+    binary: Option<&'c mut BinaryCb<'d>>,
+    hunk: Option<&'e mut HunkCb<'f>>,
+    line: Option<&'g mut LineCb<'h>>,
 }
 
 impl Diff {
@@ -265,8 +265,8 @@ extern fn print_cb(delta: *const raw::git_diff_delta,
 }
 
 extern fn file_cb_c(delta: *const raw::git_diff_delta,
-                  progress: f32,
-                  data: *mut c_void) -> c_int {
+                    progress: f32,
+                    data: *mut c_void) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
 
@@ -279,8 +279,8 @@ extern fn file_cb_c(delta: *const raw::git_diff_delta,
 }
 
 extern fn binary_cb_c(delta: *const raw::git_diff_delta,
-                    binary: *const raw::git_diff_binary,
-                    data: *mut c_void) -> c_int {
+                      binary: *const raw::git_diff_binary,
+                      data: *mut c_void) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let binary = Binding::from_raw(binary);
@@ -288,8 +288,8 @@ extern fn binary_cb_c(delta: *const raw::git_diff_delta,
         let r = panic::wrap(|| {
             let cbs = data as *mut ForeachCallbacks;
             match (*cbs).binary {
-              Some(ref mut cb) => cb(delta, binary),
-              None => false,
+                Some(ref mut cb) => cb(delta, binary),
+                None => false,
             }
         });
         if r == Some(true) {0} else {-1}
@@ -297,8 +297,8 @@ extern fn binary_cb_c(delta: *const raw::git_diff_delta,
 }
 
 extern fn hunk_cb_c(delta: *const raw::git_diff_delta,
-                  hunk: *const raw::git_diff_hunk,
-                  data: *mut c_void) -> c_int {
+                    hunk: *const raw::git_diff_hunk,
+                    data: *mut c_void) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let hunk = Binding::from_raw(hunk);
@@ -306,8 +306,8 @@ extern fn hunk_cb_c(delta: *const raw::git_diff_delta,
         let r = panic::wrap(|| {
             let cbs = data as *mut ForeachCallbacks;
             match (*cbs).hunk {
-              Some(ref mut cb) => cb(delta, hunk),
-              None => false,
+                Some(ref mut cb) => cb(delta, hunk),
+                None => false,
             }
         });
         if r == Some(true) {0} else {-1}
@@ -315,9 +315,9 @@ extern fn hunk_cb_c(delta: *const raw::git_diff_delta,
 }
 
 extern fn line_cb_c(delta: *const raw::git_diff_delta,
-                  hunk: *const raw::git_diff_hunk,
-                  line: *const raw::git_diff_line,
-                  data: *mut c_void) -> c_int {
+                    hunk: *const raw::git_diff_hunk,
+                    line: *const raw::git_diff_line,
+                    data: *mut c_void) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let hunk = Binding::from_raw_opt(hunk);
@@ -326,8 +326,8 @@ extern fn line_cb_c(delta: *const raw::git_diff_delta,
         let r = panic::wrap(|| {
             let cbs = data as *mut ForeachCallbacks;
             match (*cbs).line {
-              Some(ref mut cb) => cb(delta, hunk, line),
-              None => false,
+                Some(ref mut cb) => cb(delta, hunk, line),
+                None => false,
             }
         });
         if r == Some(true) {0} else {-1}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1118,7 +1118,7 @@ mod tests {
     }
 
     mod foreach {
-        use diff::Diff;
+        use {Diff, DiffOptions};
         use std::fs::File;
         use std::path::Path;
         use std::borrow::Borrow;
@@ -1127,12 +1127,7 @@ mod tests {
         fn diff_init(file_path: &Path) -> Diff {
             let (td, repo) = ::test::repo_init();
             t!(t!(File::create(&td.path().join(file_path))).write_all(b"bar"));
-            let mut index = t!(repo.index());
-            t!(index.add_path(file_path));
-            let tree_oid = t!(index.write_tree());
-            let tree = t!(repo.find_tree(tree_oid));
-            let head = t!(t!(repo.find_commit(t!(t!(repo.head()).resolve()).target().unwrap())).tree());
-            t!(repo.diff_tree_to_tree(Some(&head), Some(&tree), None))
+            t!(repo.diff_tree_to_workdir(None, Some(DiffOptions::new().include_untracked(true))))
         }
 
         #[test]
@@ -1160,6 +1155,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore]
         fn file_and_hunk() {
             let path = Path::new("foo");
             let diff = diff_init(path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub use config::{Config, ConfigEntry, ConfigEntries};
 pub use cred::{Cred, CredentialHelper};
 pub use describe::{Describe, DescribeFormatOptions, DescribeOptions};
 pub use diff::{Diff, DiffDelta, DiffFile, DiffOptions, Deltas};
-pub use diff::{DiffLine, DiffHunk, DiffStats, DiffFindOptions};
+pub use diff::{DiffLine, DiffHunk, DiffStats, DiffFindOptions, DiffBinary, DiffBinaryFile};
 pub use merge::{AnnotatedCommit, MergeOptions};
 pub use error::Error;
 pub use index::{Index, IndexEntry, IndexEntries, IndexMatchedPath};
@@ -789,6 +789,31 @@ pub enum DiffFormat {
     NameOnly,
     /// like git diff --name-status
     NameStatus,
+}
+
+/// When producing a binary diff, the binary data returned will be
+/// either the deflated full ("literal") contents of the file, or
+/// the deflated binary delta between the two sides (whichever is
+/// smaller).
+#[derive(Copy, Clone)]
+pub enum DiffBinaryKind {
+    /// There is no binary delta
+    None,
+    /// The binary data is the literal contents of the file
+    Literal,
+    /// The binary data is the delta from one side to the other
+    Delta,
+}
+
+impl From<raw::git_diff_binary_t> for DiffBinaryKind {
+  fn from(kind: raw::git_diff_binary_t) -> DiffBinaryKind {
+    match kind {
+      raw::GIT_DIFF_BINARY_NONE => DiffBinaryKind::None,
+      raw::GIT_DIFF_BINARY_LITERAL => DiffBinaryKind::Literal,
+      raw::GIT_DIFF_BINARY_DELTA => DiffBinaryKind::Delta,
+      _ => panic!("Unknown git diff binary kind"),
+    }
+  }
 }
 
 bitflags! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,8 @@ pub use config::{Config, ConfigEntry, ConfigEntries};
 pub use cred::{Cred, CredentialHelper};
 pub use describe::{Describe, DescribeFormatOptions, DescribeOptions};
 pub use diff::{Diff, DiffDelta, DiffFile, DiffOptions, Deltas};
-pub use diff::{DiffLine, DiffHunk, DiffStats, DiffFindOptions, DiffBinary, DiffBinaryFile};
+pub use diff::{DiffLine, DiffHunk, DiffStats, DiffFindOptions};
+pub use diff::{DiffBinary, DiffBinaryFile, DiffBinaryKind};
 pub use merge::{AnnotatedCommit, MergeOptions};
 pub use error::Error;
 pub use index::{Index, IndexEntry, IndexEntries, IndexMatchedPath};
@@ -789,31 +790,6 @@ pub enum DiffFormat {
     NameOnly,
     /// like git diff --name-status
     NameStatus,
-}
-
-/// When producing a binary diff, the binary data returned will be
-/// either the deflated full ("literal") contents of the file, or
-/// the deflated binary delta between the two sides (whichever is
-/// smaller).
-#[derive(Copy, Clone)]
-pub enum DiffBinaryKind {
-    /// There is no binary delta
-    None,
-    /// The binary data is the literal contents of the file
-    Literal,
-    /// The binary data is the delta from one side to the other
-    Delta,
-}
-
-impl From<raw::git_diff_binary_t> for DiffBinaryKind {
-  fn from(kind: raw::git_diff_binary_t) -> DiffBinaryKind {
-    match kind {
-      raw::GIT_DIFF_BINARY_NONE => DiffBinaryKind::None,
-      raw::GIT_DIFF_BINARY_LITERAL => DiffBinaryKind::Literal,
-      raw::GIT_DIFF_BINARY_DELTA => DiffBinaryKind::Delta,
-      _ => panic!("Unknown git diff binary kind"),
-    }
-  }
 }
 
 bitflags! {


### PR DESCRIPTION
For some reason the ignored test causes segmentation faults. I've done a little debugging and as far as I can tell it's entirely inside `libgit2` code and has nothing to do with the `foreach` code I've added. It seems like the test repository isn't being fully setup correctly. I've used this new functionality on a project of mine running against real repositories and haven't encountered any crashes. I'll come back to the test at some point soon, any hints you could give me on why the test repository might be different would be useful.