### PR TITLE
Update libgit2 to c8fe6c097

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -51,7 +51,7 @@ impl<'repo> Blame<'repo> {
     /// commit.
     pub fn get_line(&self, lineno: usize) -> Option<BlameHunk> {
         unsafe {
-            let ptr = raw::git_blame_get_hunk_byline(self.raw(), lineno as u32);
+            let ptr = raw::git_blame_get_hunk_byline(self.raw(), lineno);
             if ptr.is_null() {
                 None
             } else {
@@ -91,7 +91,7 @@ impl<'blame> BlameHunk<'blame> {
     ///
     /// Note that the start line is counting from 1.
     pub fn final_start_line(&self) -> usize {
-        unsafe { (*self.raw).final_start_line_number as usize }
+        unsafe { (*self.raw).final_start_line_number }
     }
 
     /// Returns the OID of the commit where this hunk was found.
@@ -112,7 +112,7 @@ impl<'blame> BlameHunk<'blame> {
     ///
     /// Note that the start line is counting from 1.
     pub fn orig_start_line(&self) -> usize {
-        unsafe { (*self.raw).orig_start_line_number as usize }
+        unsafe { (*self.raw).orig_start_line_number}
     }
 
     /// Returns path to the file where this hunk originated.

--- a/src/call.rs
+++ b/src/call.rs
@@ -136,6 +136,7 @@ mod impls {
     impl Convert<raw::git_config_level_t> for ConfigLevel {
         fn convert(&self) -> raw::git_config_level_t {
             match *self {
+                ConfigLevel::ProgramData => raw::GIT_CONFIG_LEVEL_PROGRAMDATA,
                 ConfigLevel::System => raw::GIT_CONFIG_LEVEL_SYSTEM,
                 ConfigLevel::XDG => raw::GIT_CONFIG_LEVEL_XDG,
                 ConfigLevel::Global => raw::GIT_CONFIG_LEVEL_GLOBAL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,9 @@ pub enum RepositoryState {
     Clean,
     Merge,
     Revert,
+    RevertSequence,
     CherryPick,
+    CherryPickSequence,
     Bisect,
     Rebase,
     RebaseInteractive,
@@ -302,6 +304,8 @@ pub enum BranchType {
 /// searching for config entries.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub enum ConfigLevel {
+    /// System-wide on Windows, for compatibility with portable git
+    ProgramData,
     /// System-wide configuration file, e.g. /etc/gitconfig
     System,
     /// XDG-compatible configuration file, e.g. ~/.config/git/config
@@ -542,6 +546,7 @@ impl ConfigLevel {
     /// Converts a raw configuration level to a ConfigLevel
     pub fn from_raw(raw: raw::git_config_level_t) -> ConfigLevel {
         match raw {
+            raw::GIT_CONFIG_LEVEL_PROGRAMDATA => ConfigLevel::ProgramData,
             raw::GIT_CONFIG_LEVEL_SYSTEM => ConfigLevel::System,
             raw::GIT_CONFIG_LEVEL_XDG => ConfigLevel::XDG,
             raw::GIT_CONFIG_LEVEL_GLOBAL => ConfigLevel::Global,

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -43,9 +43,9 @@ impl MergeOptions {
     /// Detect file renames
     pub fn find_renames(&mut self, find: bool) -> &mut MergeOptions {
         if find {
-            self.raw.tree_flags |= raw::GIT_MERGE_TREE_FIND_RENAMES;
+            self.raw.flags |= raw::GIT_MERGE_FIND_RENAMES;
         } else {
-            self.raw.tree_flags &= !raw::GIT_MERGE_TREE_FIND_RENAMES;
+            self.raw.flags &= !raw::GIT_MERGE_FIND_RENAMES;
         }
         self
     }
@@ -65,13 +65,22 @@ impl MergeOptions {
         self
     }
 
+    /// Maximum number of times to merge common ancestors to build a
+    /// virtual merge base when faced with criss-cross merges.  When
+    /// this limit is reached, the next ancestor will simply be used
+    /// instead of attempting to merge it.  The default is unlimited.
+    pub fn recursion_limit(&mut self, limit: u32) -> &mut MergeOptions {
+        self.raw.recursion_limit = limit as c_uint;
+        self
+    }
+
     /// Specify a side to favor for resolving conflicts
     pub fn file_favor(&mut self, favor: FileFavor) -> &mut MergeOptions {
         self.raw.file_favor = favor.convert();
         self
     }
 
-    fn flag(&mut self, opt: u32, val: bool) -> &mut MergeOptions {
+    fn flag(&mut self, opt: raw::git_merge_file_flag_t, val: bool) -> &mut MergeOptions {
         if val {
             self.raw.file_flags |= opt;
         } else {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -212,7 +212,9 @@ impl Repository {
             GIT_REPOSITORY_STATE_NONE => Clean,
             GIT_REPOSITORY_STATE_MERGE => Merge,
             GIT_REPOSITORY_STATE_REVERT => Revert,
+            GIT_REPOSITORY_STATE_REVERT_SEQUENCE => RevertSequence,
             GIT_REPOSITORY_STATE_CHERRYPICK => CherryPick,
+            GIT_REPOSITORY_STATE_CHERRYPICK_SEQUENCE => CherryPickSequence,
             GIT_REPOSITORY_STATE_BISECT => Bisect,
             GIT_REPOSITORY_STATE_REBASE => Rebase,
             GIT_REPOSITORY_STATE_REBASE_INTERACTIVE => RebaseInteractive,
@@ -1093,9 +1095,6 @@ impl Repository {
     /// are written to the index. Callers should inspect the repository's index
     /// after this completes, resolve any conflicts and prepare a commit.
     ///
-    /// The merge performed uses the first common ancestor, unlike the
-    /// git-merge-recursive strategy, which may produce an artificial common
-    /// ancestor tree when there are multiple ancestors.
     /// For compatibility with git, the repository is put into a merging state.
     /// Once the commit is done (or if the uses wishes to abort), you should
     /// clear this state by calling git_repository_state_cleanup().
@@ -1131,12 +1130,6 @@ impl Repository {
     /// the merge. The index may be written as-is to the working directory or
     /// checked out. If the index is to be converted to a tree, the caller
     /// should resolve any conflicts that arose as part of the merge.
-    ///
-    /// The merge performed uses the first common ancestor, unlike the
-    /// git-merge-recursive strategy, which may produce an artificial common
-    /// ancestor tree when there are multiple ancestors.
-    ///
-    /// The returned index must be freed explicitly with git_index_free.
     pub fn merge_commits(&self, our_commit: &Commit, their_commit: &Commit,
                          opts: Option<&MergeOptions>) -> Result<Index, Error> {
          let mut raw = 0 as *mut raw::git_index;


### PR DESCRIPTION
This is the libgit2 version that'll be the first rc. It doesn't look like you generally follow releases, but I've been going around a few bindings to update them, so here it is.

I don't know how you handle version numbers, so I haven't touched them here.