### PR TITLE
Update to rust-url 1.0

### DIFF
--- a/git2-curl/Cargo.toml
+++ b/git2-curl/Cargo.toml
@@ -15,7 +15,7 @@ Intended to be used with the git2 crate.
 
 [dependencies]
 curl = "0.2"
-url = "0.5"
+url = "1.0"
 log = "0.3"
 git2 = { path = "..", version = "0.4" }
 

--- a/git2-curl/src/lib.rs
+++ b/git2-curl/src/lib.rs
@@ -138,8 +138,8 @@ impl CurlSubtransport {
         let parsed = try!(Url::parse(&url).map_err(|_| {
             self.err("invalid url, failed to parse")
         }));
-        let host = match parsed.host() {
-            Some(host) => host.to_string(),
+        let host = match parsed.host_str() {
+            Some(host) => host,
             None => return Err(self.err("invalid url, did not have a host")),
         };
 
@@ -149,7 +149,7 @@ impl CurlSubtransport {
         let mut req = Request::new(&mut h.0, self.method)
                               .uri(url)
                               .header("User-Agent", &agent)
-                              .header("Host", &host)
+                              .header("Host", host)
                               .follow_redirects(true);
         if data.len() > 0 {
             req = req.body(&mut data)


### PR DESCRIPTION
The code change is not strictly necessary but it saves a `String` allocation.

This is not a breaking change since `Url` is not part of the public API.