### PR TITLE
Please support GIT_CHECKOUT_RECREATE_MISSING

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -559,6 +559,7 @@ git_enum! {
         GIT_CHECKOUT_NONE = 0,
         GIT_CHECKOUT_SAFE = (1 << 0),
         GIT_CHECKOUT_FORCE = (1 << 1),
+        GIT_CHECKOUT_RECREATE_MISSING = (1 << 2),
         GIT_CHECKOUT_ALLOW_CONFLICTS = (1 << 4),
         GIT_CHECKOUT_REMOVE_UNTRACKED = (1 << 5),
         GIT_CHECKOUT_REMOVE_IGNORED = (1 << 6),

--- a/src/build.rs
+++ b/src/build.rs
@@ -208,6 +208,13 @@ impl<'cb> CheckoutBuilder<'cb> {
         self
     }
 
+    /// In safe mode, create files that don't exist.
+    ///
+    /// Defaults to false.
+    pub fn recreate_missing(&mut self, allow: bool) -> &mut CheckoutBuilder<'cb> {
+        self.flag(raw::GIT_CHECKOUT_RECREATE_MISSING, allow)
+    }
+
     /// In safe mode, apply safe file updates even when there are conflicts
     /// instead of canceling the checkout.
     ///


### PR DESCRIPTION
CheckoutBuilder doesn't seem to support the `GIT_CHECKOUT_RECREATE_MISSING` flag for checkout_opts; this prevents checkout from creating files that don't already exist, without enabling `.force()` (which would also allow unsafe operations like overwriting existing data).  Please consider adding a binding for this.