### PR TITLE
Please provide bindings for git_reference_ensure_log and git_reference_has_log

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1679,6 +1679,10 @@ extern {
                                          target: *const c_char,
                                          force: c_int,
                                          log_message: *const c_char) -> c_int;
+    pub fn git_reference_has_log(repo: *mut git_repository,
+                                 name: *const c_char) -> c_int;
+    pub fn git_reference_ensure_log(repo: *mut git_repository,
+                                    name: *const c_char) -> c_int;
 
     // submodules
     pub fn git_submodule_add_finalize(submodule: *mut git_submodule) -> c_int;


### PR DESCRIPTION
`git_reference_ensure_log`, in particular, looks like the only way to force the existence of a reflog for a ref outside the normal branch namespace (similar to "HEAD").