### PR TITLE
Please support git_repository_set_index

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1419,6 +1419,8 @@ extern {
     pub fn git_repository_workdir(repo: *mut git_repository) -> *const c_char;
     pub fn git_repository_index(out: *mut *mut git_index,
                                 repo: *mut git_repository) -> c_int;
+    pub fn git_repository_set_index(repo: *mut git_repository,
+                                    index: *mut git_index) -> c_int;
     pub fn git_repository_config(out: *mut *mut git_config,
                                  repo: *mut git_repository) -> c_int;
     pub fn git_repository_config_snapshot(out: *mut *mut git_config,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -675,6 +675,14 @@ impl Repository {
         }
     }
 
+    /// Set the Index file for this repository.
+    pub fn set_index(&self, index: &mut Index) -> Result<(), Error> {
+        unsafe {
+            try_call!(raw::git_repository_set_index(self.raw(), index.raw()));
+        }
+        Ok(())
+    }
+
     /// Get the configuration file for this repository.
     ///
     /// If a configuration file has not been set, the default config set for the


### PR DESCRIPTION
libgit2 provides a function `git_repository_set_index` to set the index of a repository, useful for doing index-based operations without disrupting the current state in `.git/index`.  Please consider providing a `git::Repository::set_index` function to access that.