### PR TITLE
Add binding for git_diff_index_to_index

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2332,6 +2332,11 @@ extern {
                               idx: size_t) -> *const git_diff_delta;
     pub fn git_diff_get_stats(out: *mut *mut git_diff_stats,
                               diff: *mut git_diff) -> c_int;
+    pub fn git_diff_index_to_index(diff: *mut *mut git_diff,
+                                   repo: *mut git_repository,
+                                   old_index: *mut git_index,
+                                   new_index: *mut git_index,
+                                   opts: *const git_diff_options) -> c_int;
     pub fn git_diff_index_to_workdir(diff: *mut *mut git_diff,
                                      repo: *mut git_repository,
                                      index: *mut git_index,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1455,6 +1455,26 @@ impl Repository {
         }
     }
 
+    /// Create a diff between two index objects.
+    ///
+    /// The first index will be used for the "old_file" side of the delta, and
+    /// the second index will be used for the "new_file" side of the delta.
+    pub fn diff_index_to_index(&self,
+                               old_index: &Index,
+                               new_index: &Index,
+                               opts: Option<&mut DiffOptions>)
+                               -> Result<Diff, Error> {
+        let mut ret = 0 as *mut raw::git_diff;
+        unsafe {
+            try_call!(raw::git_diff_index_to_index(&mut ret,
+                                                   self.raw(),
+                                                   old_index.raw(),
+                                                   new_index.raw(),
+                                                   opts.map(|s| s.raw())));
+            Ok(Binding::from_raw(ret))
+        }
+    }
+
     /// Create a diff between the repository index and the workdir directory.
     ///
     /// This matches the `git diff` command.  See the note below on


### PR DESCRIPTION
This makes it easier to prepare in-memory diffs without involving a working
copy.