### PR TITLE
Adding build note for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,27 @@ $ cd git2-rs
 $ cargo build
 ```
 
+## Building on OSX 10.10+
+
+Currently libssh2 requires linking against OpenSSL, and to compile libssh2 it
+also needs to find the OpenSSL headers. On OSX 10.10+ the OpenSSL headers have
+been removed, but if you're using Homebrew you can install them via:
+
+```sh
+brew install openssl
+```
+
+To get this library to pick them up the [standard `rust-openssl`
+instructions][instr] can be used to transitively inform libssh2-sys about where
+the header files are:
+
+[instr]: https://github.com/sfackler/rust-openssl#osx
+
+```sh
+export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
+export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
+```
+
 # License
 
 `git2-rs` is primarily distributed under the terms of both the MIT license and


### PR DESCRIPTION
Hey @alexcrichton 
I've added the note for building on OS X and avoid the follow error:

```bash
Make Error at /usr/local/Cellar/cmake/3.4.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.4.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:388 (_FPHSA_FAILURE_MESSAGE)
  /usr/local/Cellar/cmake/3.4.1/share/cmake/Modules/FindOpenSSL.cmake:367 (find_package_handle_standard_args)
  src/CMakeLists.txt:62 (find_package)
```

Based on https://github.com/alexcrichton/ssh2-rs/issues/28

Cheers