### PR TITLE
add support for checkout notifications

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -6,13 +6,6 @@ use std::path::Path;
 use libc::{c_char, size_t, c_void, c_uint, c_int};
 
 use {raw, panic, Error, Repository, FetchOptions, IntoCString, CheckoutNotificationType, DiffFile};
-use {
-    CHECKOUT_NOTIFICATION_CONFLICT,
-    CHECKOUT_NOTIFICATION_DIRTY,
-    CHECKOUT_NOTIFICATION_UPDATED,
-    CHECKOUT_NOTIFICATION_UNTRACKED,
-    CHECKOUT_NOTIFICATION_IGNORED,
-};
 use util::{self, Binding};
 
 /// A builder struct which is used to build configuration for cloning a new git
@@ -315,68 +308,14 @@ impl<'cb> CheckoutBuilder<'cb> {
         self.flag(raw::GIT_CHECKOUT_CONFLICT_STYLE_MERGE, on)
     }
 
-    /// Indicate whether a notification callback should never be invoked.
+    /// Specify for which notification types to invoke the notification
+    /// callback.
     ///
-    /// This is the default.
-    pub fn never_notify(&mut self) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flags = CheckoutNotificationType::empty();
+    /// Defaults to none.
+    pub fn notify_on(&mut self, notification_types: CheckoutNotificationType)
+                     -> &mut CheckoutBuilder<'cb> {
+        self.notify_flags = notification_types;
         self
-    }
-
-    /// Invoke a notification callback for every notification type.
-    pub fn always_notify(&mut self) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flags = CheckoutNotificationType::all();
-        self
-    }
-
-    fn notify_flag(&mut self, bit: CheckoutNotificationType,
-            on: bool) -> &mut CheckoutBuilder<'cb> {
-        if on {
-            self.notify_flags.insert(bit);
-        } else {
-            self.notify_flags.remove(bit);
-        }
-        self
-    }
-
-    /// Indicate whether a notification callback should be invoked for
-    /// notifications of conflicts.
-    ///
-    /// Defaults to false.
-    pub fn notify_on_conflict(&mut self, on_conflict: bool) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flag(CHECKOUT_NOTIFICATION_CONFLICT, on_conflict)
-    }
-
-    /// Indicate whether a notification callback should be invoked for
-    /// notifications of dirty files.
-    ///
-    /// Defaults to false.
-    pub fn notify_on_dirty(&mut self, on_dirty: bool) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flag(CHECKOUT_NOTIFICATION_DIRTY, on_dirty)
-    }
-
-    /// Indicate whether a notification callback should be invoked for
-    /// notifications of changed files.
-    ///
-    /// Defaults to false.
-    pub fn notify_on_updated(&mut self, on_updated: bool) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flag(CHECKOUT_NOTIFICATION_UPDATED, on_updated)
-    }
-
-    /// Indicate whether a notification callback should be invoked for
-    /// notifications of untracked files.
-    ///
-    /// Defaults to false.
-    pub fn notify_on_untracked(&mut self, on_untracked: bool) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flag(CHECKOUT_NOTIFICATION_UNTRACKED, on_untracked)
-    }
-
-    /// Indicate whether a notification callback should be invoked for
-    /// notifications of ignored files.
-    ///
-    /// Defaults to false.
-    pub fn notify_on_ignored(&mut self, on_ignored: bool) -> &mut CheckoutBuilder<'cb> {
-        self.notify_flag(CHECKOUT_NOTIFICATION_IGNORED, on_ignored)
     }
 
     /// Indicates whether to include common ancestor data in diff3 format files

--- a/src/build.rs
+++ b/src/build.rs
@@ -552,7 +552,7 @@ extern fn notify_cb(why: raw::git_checkout_notify_t,
                  DiffFile::from_raw(baseline),
                  DiffFile::from_raw(target),
                  DiffFile::from_raw(workdir))
-    }).unwrap()
+    }).unwrap_or(1)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,6 +797,24 @@ bitflags! {
     }
 }
 
+bitflags! {
+    #[doc = "
+Types of notifications emitted from checkouts.
+"]
+    flags CheckoutNotificationType: u32 {
+        /// Notification about a conflict.
+        const CHECKOUT_NOTIFICATION_CONFLICT = raw::GIT_CHECKOUT_NOTIFY_CONFLICT as u32,
+        /// Notification about a dirty file.
+        const CHECKOUT_NOTIFICATION_DIRTY = raw::GIT_CHECKOUT_NOTIFY_DIRTY as u32,
+        /// Notification about an updated file.
+        const CHECKOUT_NOTIFICATION_UPDATED = raw::GIT_CHECKOUT_NOTIFY_UPDATED as u32,
+        /// Notification about an untracked file.
+        const CHECKOUT_NOTIFICATION_UNTRACKED = raw::GIT_CHECKOUT_NOTIFY_UNTRACKED as u32,
+        /// Notification about an ignored file.
+        const CHECKOUT_NOTIFICATION_IGNORED = raw::GIT_CHECKOUT_NOTIFY_IGNORED as u32,
+    }
+}
+
 /// Possible output formats for diff data
 #[derive(Copy, Clone)]
 pub enum DiffFormat {


### PR DESCRIPTION
This introduces a `.notify()` method on `CheckoutBuilder` which makes it
possible to register a checkout notification callback.

This also introduces the `CheckoutNotificationType` type which
represents the type of checkout notification.

There are a variety of methods such as `.notify_on_conflict()` added to
`CheckoutBuilder` which allow granular toggling of which kinds of
notifications to invoke the callback on.

---

I was going through the libgit2 documentation and noticed that there was a way [[0]](https://libgit2.github.com/libgit2/#HEAD/type/git_checkout_notify_t) [[1]](https://libgit2.github.com/libgit2/#HEAD/group/callback/git_checkout_notify_cb) to get notifications about different events while doing a checkout, so I wanted to try out what that was like and expanded the bindings for it. As usual, most of this stuff already existed in libgit2-sys, so I just wired things up!

I'd love to hear any feedback. Perhaps I'm going about it entirely the wrong way. I tried it in my downstream project and it seems great :smile: 

With respect to the various methods I added to `CheckoutBuilder` for granular toggling of the notification types, I'm not sure what you would prefer. Naively I was thinking to just have something like `.notify_on(notifications: CheckoutNotificationType)` but I saw other methods on `CheckoutBuilder` that are specific, so I added one for each, e.g. `.notify_on_conflict(on_conflict: bool)`. Perhaps I misunderstood, so if you prefer a single method like I was originally going to do, let me know and I'll set that up!

With respect to registering the callback, I used the same strategy you already use with the progress callback.