### PR TITLE
allow passing RemoteCallbacks to Remote.connect()

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -96,11 +96,14 @@ impl<'repo> Remote<'repo> {
     }
 
     /// Open a connection to a remote.
-    pub fn connect(&mut self, dir: Direction) -> Result<(), Error> {
+    pub fn connect(&mut self, dir: Direction,
+                   callbacks: Option<&mut RemoteCallbacks>)
+                   -> Result<(), Error> {
         // TODO: can callbacks be exposed safely?
+        let cbs = callbacks.map(|cb| cb.raw());
         unsafe {
             try_call!(raw::git_remote_connect(self.raw, dir,
-                                              0 as *const _,
+                                              cbs.as_ref(),
                                               0 as *const _));
         }
         Ok(())


### PR DESCRIPTION
Otherwise it's impossible to connect to remotes that require authentication.