### PR TITLE
Updated build instructions for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,13 @@ been removed, but if you're using Homebrew you can install them via:
 brew install openssl
 ```
 
-To get this library to pick them up the [standard `rust-openssl`
-instructions][instr] can be used to transitively inform libssh2-sys about where
-the header files are:
-
-[instr]: https://github.com/sfackler/rust-openssl#osx
+To get this library to pick them up the brew prefix command can be used to
+transitively inform libssh2-sys about where the header files are:
 
 ```sh
 export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
 export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
+export OPENSSL_ROOT_DIR=`brew --prefix openssl`
 ```
 
 # License


### PR DESCRIPTION
The instructions given for building from homebrew on OSX didn't work for me. I found that the OPENSSL_ROOT_DIR env variable was needed instead. I left the old commands in case they are needed on other systems as they didn't affect the fix in my testing.

Resolves #147 