### PR TITLE
Implement PartialEq for git2::Error (and thus Result<T, git2::Error>)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use libc::c_int;
 use {raw, ErrorClass, ErrorCode};
 
 /// A structure to represent errors coming out of libgit2.
-#[derive(Debug)]
+#[derive(Debug,PartialEq)]
 pub struct Error {
     code: c_int,
     klass: c_int,


### PR DESCRIPTION
This allows comparing Error values using == and !=, which in turn also
allows comparing Result<T, Error> for any T that implements PartialEq.