### PR TITLE
Fix compilation of libgit2-sys on Illumos/Solaris

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -54,6 +54,8 @@ openssl-sys = "0.7.0"
 openssl-sys = "0.7.0"
 [target.x86_64-unknown-dragonfly.dependencies]
 openssl-sys = "0.7.0"
+[target.x86_64-sun-solaris.dependencies]
+openssl-sys = "0.7.0"
 
 [features]
 ssh = ["libssh2-sys"]


### PR DESCRIPTION
This patch fixes the following compilation error on Illumos/Solaris OSes:
```
git2-rs/libgit2-sys/lib.rs:8:1: 8:37 error: can't find crate for `openssl` [E0463]
git2-rs/libgit2-sys/lib.rs:8 extern crate openssl_sys as openssl;
```