### PR TITLE
Please support discovering repositories using the standard git environment variables

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -867,6 +867,8 @@ git_enum! {
         GIT_REPOSITORY_OPEN_NO_SEARCH = (1 << 0),
         GIT_REPOSITORY_OPEN_CROSS_FS = (1 << 1),
         GIT_REPOSITORY_OPEN_BARE = (1 << 2),
+        GIT_REPOSITORY_OPEN_NO_DOTGIT = (1 << 3),
+        GIT_REPOSITORY_OPEN_FROM_ENV = (1 << 4),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,6 +461,10 @@ bitflags! {
         const REPOSITORY_OPEN_CROSS_FS = raw::GIT_REPOSITORY_OPEN_CROSS_FS as u32,
         /// Force opening as bare repository, and defer loading its config.
         const REPOSITORY_OPEN_BARE = raw::GIT_REPOSITORY_OPEN_BARE as u32,
+        /// Don't try appending `/.git` to the specified repository path.
+        const REPOSITORY_OPEN_NO_DOTGIT = raw::GIT_REPOSITORY_OPEN_NO_DOTGIT as u32,
+        /// Respect environment variables like `$GIT_DIR`.
+        const REPOSITORY_OPEN_FROM_ENV = raw::GIT_REPOSITORY_OPEN_FROM_ENV as u32,
     }
 }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -75,6 +75,13 @@ impl Repository {
     /// bare even if it isn't, ignoring any working directory, and defer
     /// loading the repository configuration for performance.
     ///
+    /// If flags contains REPOSITORY_OPEN_NO_DOTGIT, don't try appending
+    /// `/.git` to `path`.
+    ///
+    /// If flags contains REPOSITORY_OPEN_FROM_ENV, `open_ext` will ignore
+    /// other flags and `ceiling_dirs`, and respect the same environment
+    /// variables git does. Note, however, that `path` overrides `$GIT_DIR`.
+    ///
     /// ceiling_dirs specifies a list of paths that the search through parent
     /// directories will stop before entering.  Use the functions in std::env
     /// to construct or manipulate such a path list.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -60,6 +60,23 @@ impl Repository {
         }
     }
 
+    /// Find and open an existing repository, respecting git environment
+    /// variables.  This acts like `open_ext` with the
+    /// `REPOSITORY_OPEN_FROM_ENV` flag, but additionally respects `$GIT_DIR`.
+    /// With `$GIT_DIR` unset, this will search for a repository starting in
+    /// the current directory.
+    pub fn open_from_env() -> Result<Repository, Error> {
+        init();
+        let mut ret = 0 as *mut raw::git_repository;
+        unsafe {
+            try_call!(raw::git_repository_open_ext(&mut ret,
+                                                   0 as *const _,
+                                                   raw::GIT_REPOSITORY_OPEN_FROM_ENV,
+                                                   0 as *const _));
+            Ok(Binding::from_raw(ret))
+        }
+    }
+
     /// Find and open an existing repository, with additional options.
     ///
     /// If flags contains REPOSITORY_OPEN_NO_SEARCH, the path must point
@@ -80,7 +97,8 @@ impl Repository {
     ///
     /// If flags contains REPOSITORY_OPEN_FROM_ENV, `open_ext` will ignore
     /// other flags and `ceiling_dirs`, and respect the same environment
-    /// variables git does. Note, however, that `path` overrides `$GIT_DIR`.
+    /// variables git does. Note, however, that `path` overrides `$GIT_DIR`; to
+    /// respect `$GIT_DIR` as well, use `open_from_env`.
     ///
     /// ceiling_dirs specifies a list of paths that the search through parent
     /// directories will stop before entering.  Use the functions in std::env


### PR DESCRIPTION
`git::Repository::discover` passes specific default arguments to the underlying `git_repository_discover` function, which prevents respecting `$GIT_DISCOVERY_ACROSS_FILESYSTEM` or `$GIT_CEILING_DIRECTORIES`.  Please consider providing a binding that allows passing these values explicitly (as a bool and a &str), and please consider making the default binding respect the default values.

In addition, please also consider providing a function `discover_default` or similar, which doesn't take a path parameter, and which defaults to `$GIT_DIR` (or "." if that doesn't exist).

Also see https://github.com/libgit2/libgit2/issues/3711 in libgit2, which requests a new underlying C API for that case.  However, it should be easy for git2-rs to support this with or without the underlying function.
