### PR TITLE
Enable curl support in libgit2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,13 @@ after_success:
 notifications:
   email:
     on_success: never
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: osx
+      rust: stable
+      before_install:
+        - export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include
+        - export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib
 addons:
   apt:
     sources:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ tempdir = "0.3"
 
 [features]
 unstable = []
-default = ["ssh", "https"]
+default = ["ssh", "https", "curl"]
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https"]
+curl = ["libgit2-sys/curl"]
 
 [workspace]
 members = ["systest", "git2-curl"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - set PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - if defined MSYS_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin
+  - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
   - set CARGO_TARGET_DIR=%APPVEYOR_BUILD_FOLDER%\target
   - rustc -V
   - cargo -V

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -14,8 +14,9 @@ name = "libgit2_sys"
 path = "lib.rs"
 
 [dependencies]
-libssh2-sys = { version = ">= 0", optional = true }
+curl-sys = { version = ">= 0", optional = true }
 libc = "0.2"
+libssh2-sys = { version = ">= 0", optional = true }
 libz-sys = ">= 0"
 
 [build-dependencies]
@@ -60,3 +61,4 @@ openssl-sys = "0.7.0"
 [features]
 ssh = ["libssh2-sys"]
 https = []
+curl = ["curl-sys"]

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -19,11 +19,15 @@ macro_rules! t {
 fn main() {
     let https = env::var("CARGO_FEATURE_HTTPS").is_ok();
     let ssh = env::var("CARGO_FEATURE_SSH").is_ok();
+    let curl = env::var("CARGO_FEATURE_CURL").is_ok();
     if ssh {
         register_dep("SSH2");
     }
     if https {
         register_dep("OPENSSL");
+    }
+    if curl {
+        register_dep("CURL");
     }
     let has_pkgconfig = Command::new("pkg-config").output().is_ok();
 
@@ -101,13 +105,17 @@ fn main() {
     } else {
         cfg.define("USE_OPENSSL", "OFF");
     }
+    if curl {
+        cfg.register_dep("CURL");
+    } else {
+        cfg.define("CURL", "OFF");
+    }
 
     let _ = fs::remove_dir_all(env::var("OUT_DIR").unwrap());
     t!(fs::create_dir_all(env::var("OUT_DIR").unwrap()));
 
     let dst = cfg.define("BUILD_SHARED_LIBS", "OFF")
                  .define("BUILD_CLAR", "OFF")
-                 .define("CURL", "OFF")
                  .register_dep("Z")
                  .build();
 

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -4,6 +4,8 @@
 extern crate libc;
 #[cfg(feature = "ssh")]
 extern crate libssh2_sys as libssh2;
+#[cfg(feature = "curl")]
+extern crate curl_sys;
 #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), feature = "https"))]
 extern crate openssl_sys as openssl;
 extern crate libz_sys as libz;


### PR DESCRIPTION
Add a feature for using libgit2's direct support for curl, avoiding the need for
the `git2-curl` crate.