### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ libgit2 bindings for Rust
 
 ```toml
 [dependencies]
-git2 = "0.3"
+git2 = "0.5"
 ```
 
 ## Building git2-rs


### PR DESCRIPTION
Cargo says we should use `git2 = "0.5.0"`