### PR TITLE
Add bindings for creating and extracting GPG signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "git2"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "libgit2-sys"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 links = "git2"
 build = "build.rs"

--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1967,6 +1967,16 @@ extern {
     pub fn git_commit_header_field(out: *mut git_buf,
                                    commit: *const git_commit,
                                    field: *const c_char) -> c_int;
+    pub fn git_commit_create_with_signature(id: *mut git_oid,
+                                            repo: *mut git_repository,
+                                            commit_content: *const c_char,
+                                            signature: *const c_char,
+                                            signature_field: *const c_char) -> c_int;
+    pub fn git_commit_extract_signature(signature: *mut git_buf,
+                                        signed_data: *mut git_buf,
+                                        repo: *mut git_repository,
+                                        commit_id: *mut git_oid,
+                                        field: *const c_char) -> c_int;
 
     // branch
     pub fn git_branch_create(out: *mut *mut git_reference,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -819,6 +819,54 @@ impl Repository {
         }
     }
 
+    /// Create a commit object from the given buffer and signature
+    ///
+    /// Given the unsigned commit object's contents, its signature and the
+    /// header field in which to store the signature, attach the signature to
+    /// the commit and write it into the given repository.
+    ///
+    /// Use `None` in `signature_field` to use the default of `gpgsig`, which is
+    /// almost certainly what you want.
+    ///
+    /// Returns the resulting (signed) commit id.
+    pub fn signed_commit(&self,
+                         commit_content: &str,
+                         signature: &str,
+                         signature_field: Option<&str>) -> Result<Oid, Error> {
+        let commit_content = try!(CString::new(commit_content));
+        let signature = try!(CString::new(signature));
+        let signature_field = try!(::opt_cstr(signature_field));
+        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        unsafe {
+            try_call!(raw::git_commit_create_with_signature(&mut raw,
+                                                            self.raw(),
+                                                            commit_content,
+                                                            signature,
+                                                            signature_field));
+            Ok(Binding::from_raw(&raw as *const _))
+        }
+    }
+
+
+    /// Extract the signature from a commit
+    ///
+    /// Returns the signature and the signed data.
+    pub fn extract_signature(&self,
+                             commit: &Commit,
+                             signature_field: Option<&str>)
+                             -> Result<(Buf, Buf), Error> {
+        let signature_field = try!(::opt_cstr(signature_field));
+        let signature = Buf::new();
+        let content = Buf::new();
+        unsafe {
+            try_call!(raw::git_commit_extract_signature(signature.raw(),
+                                                        content.raw(),
+                                                        self.raw(),
+                                                        commit.id().raw() as *mut _,
+                                                        signature_field));
+            Ok((signature, content))
+        }
+    }
 
     /// Lookup a reference to one of the commits in a repository.
     pub fn find_commit(&self, oid: Oid) -> Result<Commit, Error> {


### PR DESCRIPTION
These were added in libgit2 v24
