### PR TITLE
allow empty git credential_helper

### DIFF
--- a/src/cred.rs
+++ b/src/cred.rs
@@ -232,7 +232,11 @@ impl CredentialHelper {
     // see https://www.kernel.org/pub/software/scm/git/docs/technical
     //                           /api-credentials.html#_credential_helpers
     fn add_command(&mut self, cmd: Option<&str>) {
-        let cmd = match cmd { Some(s) => s, None => return };
+        let cmd = match cmd {
+            Some("") | None => return,
+            Some(s) => s,
+        };
+
         if cmd.starts_with("!") {
             self.commands.push(cmd[1..].to_string());
         } else if cmd.starts_with("/") || cmd.starts_with("\\") ||
@@ -441,6 +445,16 @@ echo username=c
                                       .execute().unwrap();
         assert_eq!(u, "c");
         assert_eq!(p, "b");
+    }
+
+    #[test]
+    fn credential_helper6() {
+        let cfg = cfg! {
+            "credential.helper" => ""
+        };
+        assert!(CredentialHelper::new("https://example.com/foo/bar")
+                .config(&cfg)
+                .execute().is_none());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
previously, if .gitconfig had a credential_helper field that was empty
the add_command function would crash due to trying to slice the empty
command string from [1..].

Signed-off-by: Alpha Chen <achen@pivotal.io>
Signed-off-by: Andres Medina <amedina@pivotal.io>