### PR TITLE
Take RemoteCallbacks and ProxyOptions for remote::connect()

### DIFF
--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -76,7 +76,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Connect to the remote end specifying that we want to fetch information
     // from it.
-    try!(remote.connect(Direction::Fetch));
+    try!(remote.connect(Direction::Fetch, None, None));
 
     // Download the packfile and index it. This function updates the amount of
     // received data and the indexer stats which lets you inform the user about

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -35,7 +35,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Connect to the remote and call the printing function for each of the
     // remote references.
-    try!(remote.connect(Direction::Fetch));
+    try!(remote.connect(Direction::Fetch, None, None));
 
     // Get the list of references on the remote and print out their name next to
     // what they point to.

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -500,11 +500,11 @@ mod tests {
             assert_eq!(remotes.iter().next().unwrap(), Some("origin"));
         }
 
-        origin.connect(Direction::Push).unwrap();
+        origin.connect(Direction::Push, None, None).unwrap();
         assert!(origin.connected());
         origin.disconnect();
 
-        origin.connect(Direction::Fetch).unwrap();
+        origin.connect(Direction::Fetch, None, None).unwrap();
         assert!(origin.connected());
         origin.download(&[], None).unwrap();
         origin.disconnect();

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -98,12 +98,17 @@ impl<'repo> Remote<'repo> {
     }
 
     /// Open a connection to a remote.
-    pub fn connect(&mut self, dir: Direction) -> Result<(), Error> {
-        // TODO: can callbacks be exposed safely?
+    pub fn connect(&mut self, dir: Direction, cb: Option<RemoteCallbacks>,
+                   proxy_options: Option<ProxyOptions>)
+                   -> Result<(), Error> {
+        let cb = cb.as_ref().map(|m| m.raw())
+                       .unwrap_or_else(|| RemoteCallbacks::new().raw());
+        let proxy_options = proxy_options.as_ref().map(|m| m.raw())
+                        .unwrap_or_else(|| ProxyOptions::new().raw());
         unsafe {
             try_call!(raw::git_remote_connect(self.raw, dir,
-                                              0 as *const _,
-                                              0 as *const _,
+                                              &cb,
+                                              &proxy_options,
                                               0 as *const _));
         }
         Ok(())


### PR DESCRIPTION
So that we can connect to remotes with any form of authentication.

I'm not sure how this can be tested -- I didn't find any existing tests to callbacks (except for transfer) to reference from. If you have any ideas, please let me know.