### PR TITLE
feat: add cherrypick bindings

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1381,6 +1381,14 @@ pub type git_stash_cb = extern fn(index: size_t,
 pub type git_packbuilder_foreach_cb = extern fn(*const c_void, size_t,
                                                 *mut c_void) -> c_int;
 
+#[repr(C)]
+pub struct git_cherrypick_options {
+    pub version: c_uint,
+    pub mainline: c_uint,
+    pub merge_opts: git_merge_options,
+    pub checkout_opts: git_checkout_options
+}
+
 extern {
     // threads
     pub fn git_libgit2_init() -> c_int;
@@ -2591,6 +2599,13 @@ extern {
                                          progress_cb: Option<git_packbuilder_progress>,
                                          progress_cb_payload: *mut c_void) -> c_int;
     pub fn git_packbuilder_free(pb: *mut git_packbuilder);
+
+    // cherrypick
+    pub fn git_cherrypick_init_options(opts: *mut git_cherrypick_options,
+                                       version: c_uint) -> c_int;
+    pub fn git_cherrypick(repo: *mut git_repository,
+                          commit: *mut git_commit,
+                          options: *const git_cherrypick_options) -> c_int;
 }
 
 pub fn init() {

--- a/src/cherrypick.rs
+++ b/src/cherrypick.rs
@@ -1,0 +1,26 @@
+use std::mem;
+
+use raw;
+
+/// Options to specify when cherry picking
+pub struct CherrypickOptions {
+    raw_opts: raw::git_cherrypick_options
+}
+
+impl CherrypickOptions {
+    /// Creates a default set of cherrypick options
+    pub fn new() -> CherrypickOptions {
+        let mut opts = CherrypickOptions {
+            raw_opts: unsafe { mem::zeroed() }
+        };
+        assert_eq!(unsafe {
+            raw::git_cherrypick_init_options(&mut opts.raw_opts, 1)
+        }, 0);
+        opts
+    }
+
+    /// Acquire a pointer to the underlying raw options
+    pub unsafe fn raw(&self) -> *const raw::git_cherrypick_options {
+        &self.raw_opts as *const _
+    }
+}

--- a/src/cherrypick.rs
+++ b/src/cherrypick.rs
@@ -1,26 +1,59 @@
 use std::mem;
 
+use build::CheckoutBuilder;
+use merge::MergeOptions;
 use raw;
+use std::ptr;
 
 /// Options to specify when cherry picking
-pub struct CherrypickOptions {
-    raw_opts: raw::git_cherrypick_options
+pub struct CherrypickOptions<'cb> {
+    mainline: u32,
+    checkout_builder: Option<CheckoutBuilder<'cb>>,
+    merge_opts: Option<MergeOptions>
 }
 
-impl CherrypickOptions {
+impl<'cb> CherrypickOptions<'cb> {
     /// Creates a default set of cherrypick options
-    pub fn new() -> CherrypickOptions {
-        let mut opts = CherrypickOptions {
-            raw_opts: unsafe { mem::zeroed() }
+    pub fn new() -> CherrypickOptions<'cb> {
+        let opts = CherrypickOptions {
+            mainline: 1,
+            checkout_builder: None,
+            merge_opts: None
         };
-        assert_eq!(unsafe {
-            raw::git_cherrypick_init_options(&mut opts.raw_opts, 1)
-        }, 0);
         opts
     }
 
-    /// Acquire a pointer to the underlying raw options
-    pub unsafe fn raw(&self) -> *const raw::git_cherrypick_options {
-        &self.raw_opts as *const _
+    /// Set the checkout builder
+    pub fn checkout_builder(&mut self, cb: CheckoutBuilder<'cb>) -> &mut Self {
+        self.checkout_builder = Some(cb);
+        self
+    }
+
+    /// Set the merge options
+    pub fn merge_opts(&mut self, merge_opts: MergeOptions) -> &mut Self {
+        self.merge_opts = Some(merge_opts);
+        self
+    }
+
+    /// Obtain the raw pointer
+    pub fn raw(&mut self) -> *const raw::git_cherrypick_options {
+        unsafe {
+            let mut checkout_opts: raw::git_checkout_options = mem::zeroed();
+            raw::git_checkout_init_options(&mut checkout_opts, raw::GIT_CHECKOUT_OPTIONS_VERSION);
+            if let Some(ref mut cb) = self.checkout_builder {
+                cb.configure(&mut checkout_opts);
+            }
+            let mut merge_opts = mem::zeroed();
+            if let Some(ref opts) = self.merge_opts {
+                ptr::copy(opts.raw(), &mut merge_opts, 1);
+            }
+            let opts = raw::git_cherrypick_options {
+                version: 1,
+                mainline: self.mainline,
+                checkout_opts: checkout_opts,
+                merge_opts: merge_opts
+            };
+            &opts as * const _
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub use time::{Time, IndexTime};
 pub use tree::{Tree, TreeEntry, TreeIter};
 pub use treebuilder::TreeBuilder;
 pub use util::IntoCString;
+pub use cherrypick::CherrypickOptions;
 
 /// An enumeration of possible errors that can happen when working with a git
 /// repository.
@@ -496,6 +497,7 @@ mod blame;
 mod blob;
 mod branch;
 mod buf;
+mod cherrypick;
 mod commit;
 mod config;
 mod cred;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -13,6 +13,7 @@ use {AnnotatedCommit, MergeOptions, SubmoduleIgnore, SubmoduleStatus};
 use {ObjectType, Tag, Note, Notes, StatusOptions, Statuses, Status, Revwalk};
 use {RevparseMode, RepositoryInitMode, Reflog, IntoCString, Describe};
 use {DescribeOptions, TreeBuilder, Diff, DiffOptions, PackBuilder};
+use CherrypickOptions;
 use build::{RepoBuilder, CheckoutBuilder};
 use stash::{StashApplyOptions, StashCbData, stash_cb};
 use string_array::StringArray;
@@ -1775,6 +1776,18 @@ impl Repository {
         unsafe {
             let opts = opts.map(|opts| opts.raw());
             try_call!(raw::git_stash_pop(self.raw(), index, opts));
+            Ok(())
+        }
+    }
+
+    /// Perform a cherrypick
+    pub fn cherrypick(&self, commit: &Commit, options: Option<&mut CherrypickOptions>) -> Result<(), Error> {
+        unsafe {
+            try_call!(raw::git_cherrypick(self.raw(),
+                                          commit.raw(),
+                                          options.map(|s| s.raw())
+                                                 .unwrap_or(0 as *const _)));
+
             Ok(())
         }
     }


### PR DESCRIPTION
Fixes #181

Adds bindings to `git_cherrypick` and `git_cherrypick_init_options`.

Allows cherrypicking a given `Commit` through a `Repository` with the new function `cherrypick`.