### PR TITLE
Add RemoteConnection struct for Remote::connect

### DIFF
--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -76,7 +76,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Connect to the remote end specifying that we want to fetch information
     // from it.
-    try!(remote.connect(Direction::Fetch));
+    let _connection = try!(remote.connect(Direction::Fetch, None, None));
 
     // Download the packfile and index it. This function updates the amount of
     // received data and the indexer stats which lets you inform the user about

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -19,7 +19,7 @@ extern crate docopt;
 extern crate rustc_serialize;
 
 use docopt::Docopt;
-use git2::{Repository, RemoteCallbacks, Direction, AutotagOption, FetchOptions};
+use git2::{Repository, RemoteCallbacks, AutotagOption, FetchOptions};
 use std::io::{self, Write};
 use std::str;
 
@@ -73,10 +73,6 @@ fn run(args: &Args) -> Result<(), git2::Error> {
         io::stdout().flush().unwrap();
         true
     });
-
-    // Connect to the remote end specifying that we want to fetch information
-    // from it.
-    let _connection = try!(remote.connect(Direction::Fetch, None, None));
 
     // Download the packfile and index it. This function updates the amount of
     // received data and the indexer stats which lets you inform the user about

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -35,7 +35,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Connect to the remote and call the printing function for each of the
     // remote references.
-    let connection = try!(remote.connect(Direction::Fetch, None, None));
+    let connection = try!(remote.connect_auth(Direction::Fetch, None, None));
 
     // Get the list of references on the remote and print out their name next to
     // what they point to.

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -35,11 +35,11 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Connect to the remote and call the printing function for each of the
     // remote references.
-    let _connection = try!(remote.connect(Direction::Fetch, None, None));
+    let connection = try!(remote.connect(Direction::Fetch, None, None));
 
     // Get the list of references on the remote and print out their name next to
     // what they point to.
-    for head in try!(remote.list()).iter() {
+    for head in try!(connection.list()).iter() {
         println!("{}\t{}", head.oid(), head.name());
     }
     Ok(())

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -35,14 +35,13 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Connect to the remote and call the printing function for each of the
     // remote references.
-    try!(remote.connect(Direction::Fetch));
+    let _connection = try!(remote.connect(Direction::Fetch, None, None));
 
     // Get the list of references on the remote and print out their name next to
     // what they point to.
     for head in try!(remote.list()).iter() {
         println!("{}\t{}", head.oid(), head.name());
     }
-
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use proxy_options::ProxyOptions;
 pub use reference::{Reference, References, ReferenceNames};
 pub use reflog::{Reflog, ReflogEntry, ReflogIter};
 pub use refspec::Refspec;
-pub use remote::{Remote, Refspecs, RemoteHead, FetchOptions, PushOptions};
+pub use remote::{Remote, RemoteConnection, Refspecs, RemoteHead, FetchOptions, PushOptions};
 pub use remote_callbacks::{RemoteCallbacks, Credentials, TransferProgress};
 pub use remote_callbacks::{TransportMessage, Progress, UpdateTips};
 pub use repo::{Repository, RepositoryInitOptions};

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -51,10 +51,9 @@ pub struct PushOptions<'cb> {
 }
 
 /// Holds callbacks for a connection to a `Remote`. Disconnects when dropped
-#[allow(dead_code)]
 pub struct RemoteConnection<'repo, 'connection, 'cb> where 'repo: 'connection {
-    callbacks: Box<RemoteCallbacks<'cb>>,
-    proxy: Box<ProxyOptions<'cb>>,
+    _callbacks: Box<RemoteCallbacks<'cb>>,
+    _proxy: ProxyOptions<'cb>,
     remote: &'connection mut Remote<'repo>,
 }
 
@@ -115,7 +114,7 @@ impl<'repo> Remote<'repo> {
                     -> Result<RemoteConnection<'repo, 'connection, 'cb>, Error> {
 
         let cb = Box::new(cb.unwrap_or_else(|| RemoteCallbacks::new()));
-        let proxy_options = Box::new(proxy_options.unwrap_or_else(|| ProxyOptions::new()));
+        let proxy_options = proxy_options.unwrap_or_else(|| ProxyOptions::new());
         unsafe {
             try_call!(raw::git_remote_connect(self.raw, dir,
                                               &cb.raw(),
@@ -124,8 +123,8 @@ impl<'repo> Remote<'repo> {
         }
 
         Ok(RemoteConnection {
-            callbacks: cb,
-            proxy: proxy_options,
+            _callbacks: cb,
+            _proxy: proxy_options,
             remote: self,
         })
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -112,9 +112,9 @@ impl<'repo> Remote<'repo> {
     ///
     /// Returns a `RemoteConnection` that will disconnect once dropped
     pub fn connect<'connection, 'cb>(&mut self,
-                                 dir: Direction,
-                                 cb: Option<RemoteCallbacks<'cb>>,
-                                 proxy_options: Option<ProxyOptions<'cb>>)
+                                     dir: Direction,
+                                     cb: Option<RemoteCallbacks<'cb>>,
+                                     proxy_options: Option<ProxyOptions<'cb>>)
                     -> Result<RemoteConnection<'repo, 'connection, 'cb>, Error> {
 
         let cb = cb.unwrap_or_else(|| RemoteCallbacks::new());


### PR DESCRIPTION
This is a continuation of #182.

I had some difficulty implementing this without making breaking changes to `Remote`.

I had to store the raw `*mut raw::git_remote` pointer instead of `&mut Remote` because you won't be able to do anything with `Remote` as long as the connection is live otherwise. Ideally, this connection struct should be inside `Remote` like you mentioned.

For the test, for some reason, the `sideband_progress` is not actually run during the `fetch` but it's actually used somewhere. So it will cause a segfault if the callback is freed.  If you run `cargo test` in 	40bc55f it will segfault.