### PR TITLE
Update cross-reference in docs for Commit::amend

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -178,7 +178,9 @@ impl<'repo> Commit<'repo> {
     /// except that any non-`None` values will be updated. The new commit has
     /// the same parents as the old commit.
     ///
-    /// For information about `update_ref`, see `new`.
+    /// For information about `update_ref`, see [`Repository::commit`].
+    ///
+    /// [`Repository::commit`]: struct.Repository.html#method.commit
     pub fn amend(&self,
                  update_ref: Option<&str>,
                  author: Option<&Signature>,


### PR DESCRIPTION
It looks like when `Commit::new` was removed back in f53baff3058274173a82035ee06a7fa309ddce4d, a cross-reference in the docs for `Commit::amend` wasn't updated.