### PR TITLE
mingw: detect and link http_parser

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -136,16 +136,6 @@ fn main() {
         }
     }
 
-    if target.contains("windows") {
-        println!("cargo:rustc-link-lib=winhttp");
-        println!("cargo:rustc-link-lib=rpcrt4");
-        println!("cargo:rustc-link-lib=ole32");
-        println!("cargo:rustc-link-lib=crypt32");
-        println!("cargo:rustc-link-lib=static=git2");
-        println!("cargo:rustc-link-search=native={}/lib", dst.display());
-        return
-    }
-
     // libgit2 requires the http_parser library for the HTTP transport to be
     // implemented, and it will attempt to use the system http_parser if it's
     // available. Detect this situation and report using the system http parser
@@ -161,6 +151,16 @@ fn main() {
         if contents.contains("-lhttp_parser") {
             println!("cargo:rustc-link-lib=http_parser");
         }
+    }
+
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=winhttp");
+        println!("cargo:rustc-link-lib=rpcrt4");
+        println!("cargo:rustc-link-lib=ole32");
+        println!("cargo:rustc-link-lib=crypt32");
+        println!("cargo:rustc-link-lib=static=git2");
+        println!("cargo:rustc-link-search=native={}/lib", dst.display());
+        return
     }
 
     println!("cargo:rustc-link-lib=static=git2");


### PR DESCRIPTION
Ran into https://github.com/alexcrichton/git2-rs/issues/97#issuecomment-285959174 on MSYS2.

Building libgit2-sys without fix:
```
...
Running `rustc --crate-name libgit2_sys lib.rs --crate-type lib -C opt-level=3 -C metadata=68ed0633e67a30f2 -C extra-filename=-68ed0633e67a30f2 --out-dir D:\\projekty\\rust\\git2-rs\\target\\release\\deps --emit=dep-info,link -L dependency=D:\\projekty\\rust\\git2-rs\\target\\release\\deps --extern libz_sys=D:\\projekty\\rust\\git2-rs\\target\\release\\deps\\liblibz_sys-cb9681d111db8939.rlib --extern libc=D:\\projekty\\rust\\git2-rs\\target\\release\\deps\\liblibc-9ac948aa14b90e38.rlib -L native=D:\\projekty\\rust\\git2-rs\\target\\release\\build\\libgit2-sys-f67b946f88929e00\\out/lib -l winhttp -l rpcrt4 -l ole32 -l crypt32 -l static=git2 -L native=D:/msys64/mingw64/lib`
```
With fix:
```
Running `rustc --crate-name libgit2_sys lib.rs --crate-type lib -C opt-level=3 -C metadata=68ed0633e67a30f2 -C extra-filename=-68ed0633e67a30f2 --out-dir D:\\projekty\\rust\\git2-rs\\target\\release\\deps --emit=dep-info,link -L dependency=D:\\projekty\\rust\\git2-rs\\target\\release\\deps --extern libc=D:\\projekty\\rust\\git2-rs\\target\\release\\deps\\liblibc-9ac948aa14b90e38.rlib --extern libz_sys=D:\\projekty\\rust\\git2-rs\\target\\release\\deps\\liblibz_sys-cb9681d111db8939.rlib -L native=D:\\projekty\\rust\\git2-rs\\target\\release\\build\\libgit2-sys-f67b946f88929e00\\out/lib -l http_parser -l winhttp -l rpcrt4 -l ole32 -l crypt32 -l static=git2 -L native=D:/msys64/mingw64/lib`
```
As you can see `-l http_parser` is now included.

How can I build Rust with this modified libgit2-sys to see if it works?