### PR TITLE
libgit2-sys: unset DESTDIR during libgit2 build

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -120,6 +120,8 @@ fn main() {
     let _ = fs::remove_dir_all(env::var("OUT_DIR").unwrap());
     t!(fs::create_dir_all(env::var("OUT_DIR").unwrap()));
 
+    // Unset DESTDIR or libgit2.a ends up in it and cargo can't find it
+    env::remove_var("DESTDIR");
     let dst = cfg.define("BUILD_SHARED_LIBS", "OFF")
                  .define("BUILD_CLAR", "OFF")
                  .register_dep("Z")


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/41586

As we run cmake install, DESTDIR is used when defined, libgit2.a
ends up in  and we get this failure:

```
   Compiling libgit2-sys v0.6.8 (file:///home/keruspe/Sources/git2-rs/libgit2-sys)
     Running `rustc --crate-name libgit2_sys lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=8c05c334c8251b8f -C extra-filename=-8c05c334c8251b8f --out-dir /home/keruspe/Sources/git2-rs/target/debug/deps -L dependency=/home/keruspe/Sources/git2-rs/target/debug/deps --extern libz_sys=/home/keruspe/Sources/git2-rs/target/debug/deps/liblibz_sys-b34e05ee2e9e1468.rlib --extern libc=/home/keruspe/Sources/git2-rs/target/debug/deps/liblibc-5dc7b85e748840b4.rlib -L native=/home/keruspe/Sources/git2-rs/target/debug/build/libgit2-sys-7842f88a9e389e71/out/lib -l static=git2 -L native=/usr/x86_64-pc-linux-gnu/lib`
error: could not find native static library `git2`, perhaps an -L flag is missing?

error: Could not compile `libgit2-sys`.

Caused by:
  process didn't exit successfully: `rustc --crate-name libgit2_sys lib.rs --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=8c05c334c8251b8f -C extra-filename=-8c05c334c8251b8f --out-dir /home/keruspe/Sources/git2-rs/target/debug/deps -L dependency=/home/keruspe/Sources/git2-rs/target/debug/deps --extern libz_sys=/home/keruspe/Sources/git2-rs/target/debug/deps/liblibz_sys-b34e05ee2e9e1468.rlib --extern libc=/home/keruspe/Sources/git2-rs/target/debug/deps/liblibc-5dc7b85e748840b4.rlib -L native=/home/keruspe/Sources/git2-rs/target/debug/build/libgit2-sys-7842f88a9e389e71/out/lib -l static=git2 -L native=/usr/x86_64-pc-linux-gnu/lib` (exit code: 101)
```