### PR TITLE
Add `libgit2_sys::git_index_has_conflicts` and `git2::Index::has_conflicts`

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1981,6 +1981,7 @@ extern {
     pub fn git_index_get_bypath(index: *mut git_index,
                                 path: *const c_char,
                                 stage: c_int) -> *const git_index_entry;
+    pub fn git_index_has_conflicts(index: *const git_index) -> c_int;
     pub fn git_index_new(index: *mut *mut git_index) -> c_int;
     pub fn git_index_open(index: *mut *mut git_index,
                           index_path: *const c_char) -> c_int;

--- a/src/index.rs
+++ b/src/index.rs
@@ -247,6 +247,15 @@ impl Index {
         }
     }
 
+    /// Does this index have conflicts?
+    ///
+    /// Returns `true` if the index contains conflicts, `false` if it does not.
+    pub fn has_conflicts(&self) -> bool {
+        unsafe {
+            raw::git_index_has_conflicts(self.raw) == 1
+        }
+    }
+
     /// Get the full path to the index file on disk.
     ///
     /// Returns `None` if this is an in-memory index.
@@ -617,4 +626,3 @@ mod tests {
         }
     }
 }
-


### PR DESCRIPTION
r? @alexcrichton 