### PR TITLE
Added fetch_refspecs and push_refspecs bindings to remote

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1519,6 +1519,8 @@ extern {
                           source: *mut git_remote) -> c_int;
     pub fn git_remote_get_fetch_refspecs(array: *mut git_strarray,
                                          remote: *const git_remote) -> c_int;
+    pub fn git_remote_get_push_refspecs(array: *mut git_strarray,
+                                         remote: *const git_remote) -> c_int;
     pub fn git_remote_get_refspec(remote: *const git_remote,
                                   n: size_t) -> *const git_refspec;
     pub fn git_remote_is_valid_name(remote_name: *const c_char) -> c_int;

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -8,6 +8,7 @@ use libc;
 
 use {raw, Direction, Error, Refspec, Oid, FetchPrune, ProxyOptions};
 use {RemoteCallbacks, Progress, Repository, AutotagOption};
+use string_array::StringArray;
 use util::Binding;
 
 /// A structure representing a [remote][1] of a git repository.
@@ -278,6 +279,24 @@ impl<'repo> Remote<'repo> {
             let slice = slice::from_raw_parts(base as *const _, size as usize);
             Ok(mem::transmute::<&[*const raw::git_remote_head],
                                 &[RemoteHead]>(slice))
+        }
+    }
+    
+    /// Get the remote's list of fetch refspecs
+    pub fn fetch_refspecs(&self) -> Result<StringArray, Error> {
+        unsafe {
+            let mut raw: raw::git_strarray = mem::zeroed();
+            try_call!(raw::git_remote_get_fetch_refspecs(&mut raw, self.raw));
+            Ok(StringArray::from_raw(raw))
+        }
+    }
+
+    /// Get the remote's list of push refspecs
+    pub fn push_refspecs(&self) -> Result<StringArray, Error> {
+        unsafe {
+            let mut raw: raw::git_strarray = mem::zeroed();
+            try_call!(raw::git_remote_get_push_refspecs(&mut raw, self.raw));
+            Ok(StringArray::from_raw(raw))
         }
     }
 }


### PR DESCRIPTION
Not sure if `StringArray` is the best way to return the `refspecs`.