### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/cat-file.rs
+++ b/examples/cat-file.rs
@@ -46,9 +46,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     if args.flag_t {
         println!("{}", obj.kind().unwrap().str());
-    } else if args.flag_s {
-        /* ... */
-    } else if args.flag_e {
+    } else if args.flag_s || args.flag_e {
         /* ... */
     } else if args.flag_p {
         match obj.kind() {

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -49,7 +49,7 @@ fn print(state: &mut State) {
         0
     };
     let kbytes = stats.received_bytes() / 1024;
-    if stats.received_objects() == stats.total_objects() && false {
+    if stats.received_objects() == stats.total_objects() {
         if !state.newline {
             println!("");
             state.newline = true;

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -63,8 +63,10 @@ fn print(state: &mut State) {
                stats.total_objects(),
                index_pct, stats.indexed_objects(), stats.total_objects(),
                co_pct, state.current, state.total,
-               state.path.as_ref().map(|s| s.to_string_lossy().into_owned())
-                                  .unwrap_or(String::new()));
+               state.path
+                    .as_ref()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default())
     }
     io::stdout().flush().unwrap();
 }

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -186,16 +186,16 @@ fn print_stats(diff: &Diff, args: &Args) -> Result<(), Error> {
     let stats = try!(diff.stats());
     let mut format = git2::DIFF_STATS_NONE;
     if args.flag_stat {
-        format = format | git2::DIFF_STATS_FULL;
+        format |= git2::DIFF_STATS_FULL;
     }
     if args.flag_shortstat {
-        format = format | git2::DIFF_STATS_SHORT;
+        format |= git2::DIFF_STATS_SHORT;
     }
     if args.flag_numstat {
-        format = format | git2::DIFF_STATS_NUMBER;
+        format |= git2::DIFF_STATS_NUMBER;
     }
     if args.flag_summary {
-        format = format | git2::DIFF_STATS_INCLUDE_SUMMARY;
+        format |= git2::DIFF_STATS_INCLUDE_SUMMARY;
     }
     let buf = try!(stats.to_buf(format, 80));
     print!("{}", str::from_utf8(&*buf).unwrap());

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -152,8 +152,10 @@ fn run(args: &Args) -> Result<(), Error> {
         try!(diff.print(args.diff_format(), |_delta, _hunk, line| {
             if args.color() {
                 let next = match line.origin() {
-                    '+' | '>' => Some(GREEN),
-                    '-' | '<' => Some(RED),
+                    '+' => Some(GREEN),
+                    '-' => Some(RED),
+                    '>' => Some(GREEN),
+                    '<' => Some(RED),
                     'F' => Some(BOLD),
                     'H' => Some(CYAN),
                     _ => None
@@ -224,7 +226,8 @@ impl Args {
             match self.flag_format.as_ref().map(|s| &s[..]) {
                 Some("name") => DiffFormat::NameOnly,
                 Some("name-status") => DiffFormat::NameStatus,
-                Some("raw") | Some("diff-index") => DiffFormat::Raw,
+                Some("raw") => DiffFormat::Raw,
+                Some("diff-index") => DiffFormat::Raw,
                 _ => DiffFormat::Patch,
             }
         }

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -152,10 +152,8 @@ fn run(args: &Args) -> Result<(), Error> {
         try!(diff.print(args.diff_format(), |_delta, _hunk, line| {
             if args.color() {
                 let next = match line.origin() {
-                    '+' => Some(GREEN),
-                    '-' => Some(RED),
-                    '>' => Some(GREEN),
-                    '<' => Some(RED),
+                    '+' | '>' => Some(GREEN),
+                    '-' | '<' => Some(RED),
                     'F' => Some(BOLD),
                     'H' => Some(CYAN),
                     _ => None
@@ -226,8 +224,7 @@ impl Args {
             match self.flag_format.as_ref().map(|s| &s[..]) {
                 Some("name") => DiffFormat::NameOnly,
                 Some("name-status") => DiffFormat::NameStatus,
-                Some("raw") => DiffFormat::Raw,
-                Some("diff-index") => DiffFormat::Raw,
+                Some("raw") | Some("diff-index") => DiffFormat::Raw,
                 _ => DiffFormat::Patch,
             }
         }

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -55,7 +55,7 @@ fn run(args: &Args) -> Result<(), Error> {
         }
 
         if let Some(ref s) = args.flag_shared {
-            opts.mode(try!(parse_shared(&s)));
+            opts.mode(try!(parse_shared(s)));
         }
         try!(Repository::init_opts(&path, &opts))
     };

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -116,7 +116,7 @@ fn parse_shared(shared: &str) -> Result<RepositoryInitMode, Error> {
             if shared.starts_with("0") {
                 match u32::from_str_radix(&shared[1..], 8).ok() {
                     Some(n) => {
-                        return Ok(RepositoryInitMode::from_bits_truncate(n))
+                        Ok(RepositoryInitMode::from_bits_truncate(n))
                     }
                     None => {
                         Err(Error::from_str("invalid octal value for --shared"))

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -113,7 +113,7 @@ fn parse_shared(shared: &str) -> Result<RepositoryInitMode, Error> {
         "true" | "group" => Ok(git2::REPOSITORY_INIT_SHARED_GROUP),
         "all" | "world" => Ok(git2::REPOSITORY_INIT_SHARED_ALL),
         _ => {
-            if shared.starts_with("0") {
+            if shared.starts_with('0') {
                 match u32::from_str_radix(&shared[1..], 8).ok() {
                     Some(n) => {
                         Ok(RepositoryInitMode::from_bits_truncate(n))

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -60,7 +60,7 @@ fn run(args: &Args) -> Result<(), Error> {
     } else {
         git2::SORT_NONE
     });
-    for commit in args.arg_commit.iter() {
+    for commit in &args.arg_commit {
         if commit.starts_with('^') {
             let obj = try!(repo.revparse_single(&commit[1..]));
             try!(revwalk.hide(obj.id()));
@@ -87,7 +87,7 @@ fn run(args: &Args) -> Result<(), Error> {
 
     // Prepare our diff options and pathspec matcher
     let (mut diffopts, mut diffopts2) = (DiffOptions::new(), DiffOptions::new());
-    for spec in args.arg_spec.iter() {
+    for spec in &args.arg_spec {
         diffopts.pathspec(spec);
         diffopts2.pathspec(spec);
     }

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -61,7 +61,7 @@ fn run(args: &Args) -> Result<(), Error> {
         git2::SORT_NONE
     });
     for commit in args.arg_commit.iter() {
-        if commit.starts_with("^") {
+        if commit.starts_with('^') {
             let obj = try!(repo.revparse_single(&commit[1..]));
             try!(revwalk.hide(obj.id()));
             continue

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -121,8 +121,8 @@ fn run(args: &Args) -> Result<(), Error> {
                 }
             }
         }
-        if !sig_matches(commit.author(), &args.flag_author) { return None }
-        if !sig_matches(commit.committer(), &args.flag_committer) { return None }
+        if !sig_matches(&commit.author(), &args.flag_author) { return None }
+        if !sig_matches(&commit.committer(), &args.flag_committer) { return None }
         if !log_message_matches(commit.message(), &args.flag_grep) { return None }
         Some(Ok(commit))
     }).skip(args.flag_skip.unwrap_or(0)).take(args.flag_max_count.unwrap_or(!0));
@@ -154,7 +154,7 @@ fn run(args: &Args) -> Result<(), Error> {
     Ok(())
 }
 
-fn sig_matches(sig: Signature, arg: &Option<String>) -> bool {
+fn sig_matches(sig: &Signature, arg: &Option<String>) -> bool {
     match *arg {
         Some(ref s) => {
             sig.name().map(|n| n.contains(s)).unwrap_or(false) ||

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -81,7 +81,7 @@ fn run(args: &Args) -> Result<(), Error> {
             try!(revwalk.hide(from));
         }
     }
-    if args.arg_commit.len() == 0 {
+    if args.arg_commit.is_empty() {
         try!(revwalk.push_head());
     }
 
@@ -105,7 +105,7 @@ fn run(args: &Args) -> Result<(), Error> {
         if let Some(n) = args.max_parents() {
             if parents >= n { return None }
         }
-        if args.arg_spec.len() > 0 {
+        if !args.arg_spec.is_empty() {
             match commit.parents().len() {
                 0 => {
                     let tree = filter_try!(commit.tree());

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -66,7 +66,7 @@ fn run(args: &Args) -> Result<(), Error> {
             try!(revwalk.hide(obj.id()));
             continue
         }
-        let revspec = try!(repo.revparse(&commit));
+        let revspec = try!(repo.revparse(commit));
         if revspec.mode().contains(git2::REVPARSE_SINGLE) {
             try!(revwalk.push(revspec.from().unwrap().id()));
         } else {

--- a/examples/rev-list.rs
+++ b/examples/rev-list.rs
@@ -47,7 +47,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     let specs = args.flag_not.iter().map(|s| (s, true))
                     .chain(args.arg_spec.iter().map(|s| (s, false)))
                     .map(|(spec, hide)| {
-        if spec.starts_with("^") {(&spec[1..], !hide)} else {(&spec[..], hide)}
+        if spec.starts_with('^') {(&spec[1..], !hide)} else {(&spec[..], hide)}
     });
     for (spec, hide) in specs {
         let id = if spec.contains("..") {

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -27,7 +27,6 @@ use git2::{Repository, Error, StatusOptions, ErrorCode, SubmoduleIgnore};
 struct Args {
     arg_spec: Vec<String>,
     flag_short: bool,
-    flag_long: bool,
     flag_porcelain: bool,
     flag_branch: bool,
     flag_z: bool,

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -66,7 +66,7 @@ fn run(args: &Args) -> Result<(), Error> {
         None => {}
     }
     opts.include_untracked(!args.flag_ignored);
-    for spec in args.arg_spec.iter() {
+    for spec in &args.arg_spec {
         opts.pathspec(spec);
     }
 
@@ -119,7 +119,7 @@ fn show_branch(repo: &Repository, format: &Format) -> Result<(), Error> {
 fn print_submodules(repo: &Repository) -> Result<(), Error> {
     let modules = try!(repo.submodules());
     println!("# Submodules");
-    for sm in modules.iter() {
+    for sm in &modules {
         println!("# - submodule '{}' at {}", sm.name().unwrap(),
                  sm.path().display());
     }

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -43,7 +43,7 @@ struct Args {
 enum Format { Long, Short, Porcelain }
 
 fn run(args: &Args) -> Result<(), Error> {
-    let path = args.flag_git_dir.clone().unwrap_or(".".to_string());
+    let path = args.flag_git_dir.clone().unwrap_or_else(|| ".".to_string());
     let repo = try!(Repository::open(&path));
     if repo.is_bare() {
         return Err(Error::from_str("cannot report status on bare repository"))
@@ -312,8 +312,8 @@ fn print_short(repo: &Repository, statuses: git2::Statuses) {
             b = diff.new_file().path();
         }
         if let Some(diff) = entry.index_to_workdir() {
-            a = a.or(diff.old_file().path());
-            b = b.or(diff.old_file().path());
+            a.or_else(|| diff.old_file().path());
+            b.or_else(|| diff.old_file().path());
             c = diff.new_file().path();
         }
 

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -309,8 +309,8 @@ fn print_short(repo: &Repository, statuses: &git2::Statuses) {
             b = diff.new_file().path();
         }
         if let Some(diff) = entry.index_to_workdir() {
-            a.or_else(|| diff.old_file().path());
-            b.or_else(|| diff.old_file().path());
+            a = a.or_else(|| diff.old_file().path());
+            b = b.or_else(|| diff.old_file().path());
             c = diff.new_file().path();
         }
 

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -297,9 +297,7 @@ fn print_short(repo: &Repository, statuses: git2::Statuses) {
         if let Some(status) = status {
             if status.contains(git2::SUBMODULE_STATUS_WD_MODIFIED) {
                 extra = " (new commits)";
-            } else if status.contains(git2::SUBMODULE_STATUS_WD_INDEX_MODIFIED) {
-                extra = " (modified content)";
-            } else if status.contains(git2::SUBMODULE_STATUS_WD_WD_MODIFIED) {
+            } else if status.contains(git2::SUBMODULE_STATUS_WD_INDEX_MODIFIED) || status.contains(git2::SUBMODULE_STATUS_WD_WD_MODIFIED) {
                 extra = " (modified content)";
             } else if status.contains(git2::SUBMODULE_STATUS_WD_UNTRACKED) {
                 extra = " (untracked content)";
@@ -338,9 +336,7 @@ fn print_short(repo: &Repository, statuses: git2::Statuses) {
 impl Args {
     fn format(&self) -> Format {
         if self.flag_short { Format::Short }
-        else if self.flag_long { Format::Long }
-        else if self.flag_porcelain { Format::Porcelain }
-        else if self.flag_z { Format::Porcelain }
+        else if self.flag_porcelain || self.flag_z { Format::Porcelain }
         else { Format::Long }
     }
 }

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -157,7 +157,7 @@ fn print_long(statuses: &git2::Statuses) {
         let old_path = entry.head_to_index().unwrap().old_file().path();
         let new_path = entry.head_to_index().unwrap().new_file().path();
         match (old_path, new_path) {
-            (Some(ref old), Some(ref new)) if old != new => {
+            (Some(old), Some(new)) if old != new => {
                 println!("#\t{}  {} -> {}", istatus, old.display(),
                          new.display());
             }
@@ -204,7 +204,7 @@ fn print_long(statuses: &git2::Statuses) {
         let old_path = entry.index_to_workdir().unwrap().old_file().path();
         let new_path = entry.index_to_workdir().unwrap().new_file().path();
         match (old_path, new_path) {
-            (Some(ref old), Some(ref new)) if old != new => {
+            (Some(old), Some(new)) if old != new => {
                 println!("#\t{}  {} -> {}", istatus, old.display(),
                          new.display());
             }

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -78,16 +78,16 @@ fn run(args: &Args) -> Result<(), Error> {
         let statuses = try!(repo.statuses(Some(&mut opts)));
 
         if args.flag_branch {
-            try!(show_branch(&repo, args.format()));
+            try!(show_branch(&repo, &args.format()));
         }
         if args.flag_list_submodules {
             try!(print_submodules(&repo));
         }
 
         if args.format() == Format::Long {
-            print_long(statuses);
+            print_long(&statuses);
         } else {
-            print_short(&repo, statuses);
+            print_short(&repo, &statuses);
         }
 
         if args.flag_repeat {
@@ -98,7 +98,7 @@ fn run(args: &Args) -> Result<(), Error> {
     }
 }
 
-fn show_branch(repo: &Repository, format: Format) -> Result<(), Error> {
+fn show_branch(repo: &Repository, format: &Format) -> Result<(), Error> {
     let head = match repo.head() {
         Ok(head) => Some(head),
         Err(ref e) if e.code() == ErrorCode::UnbornBranch ||
@@ -107,7 +107,7 @@ fn show_branch(repo: &Repository, format: Format) -> Result<(), Error> {
     };
     let head = head.as_ref().and_then(|h| h.shorthand());
 
-    if format == Format::Long {
+    if format == &Format::Long {
         println!("# On branch {}",
                  head.unwrap_or("Not currently on any branch"));
     } else {
@@ -128,7 +128,7 @@ fn print_submodules(repo: &Repository) -> Result<(), Error> {
 
 // This function print out an output similar to git's status command in long
 // form, including the command-line hints.
-fn print_long(statuses: git2::Statuses) {
+fn print_long(statuses: &git2::Statuses) {
     let mut header = false;
     let mut rm_in_workdir = false;
     let mut changes_in_index = false;
@@ -256,7 +256,7 @@ fn print_long(statuses: git2::Statuses) {
 
 // This version of the output prefixes each path with two status columns and
 // shows submodule status information.
-fn print_short(repo: &Repository, statuses: git2::Statuses) {
+fn print_short(repo: &Repository, statuses: &git2::Statuses) {
     for entry in statuses.iter().filter(|e| e.status() != git2::STATUS_CURRENT) {
         let mut istatus = match entry.status() {
             s if s.contains(git2::STATUS_INDEX_NEW) => 'A',

--- a/examples/tag.rs
+++ b/examples/tag.rs
@@ -43,9 +43,9 @@ fn run(args: &Args) -> Result<(), Error> {
 
         if let Some(ref message) = args.flag_message {
             let sig = try!(repo.signature());
-            try!(repo.tag(&name, &obj, &sig, &message, args.flag_force));
+            try!(repo.tag(name, &obj, &sig, message, args.flag_force));
         } else {
-            try!(repo.tag_lightweight(&name, &obj, args.flag_force));
+            try!(repo.tag_lightweight(name, &obj, args.flag_force));
         }
 
     } else if let Some(ref name) = args.flag_delete {

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -140,6 +140,13 @@ impl<'blame> BlameHunk<'blame> {
     }
 }
 
+
+impl Default for BlameOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BlameOptions {
 
     /// Initialize options

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -35,6 +35,11 @@ impl<'repo> Blame<'repo> {
         unsafe { raw::git_blame_get_hunk_count(self.raw) as usize }
     }
 
+    /// Return `true` is there is no hunk in the blame structure.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Gets the blame hunk at the given index.
     pub fn get_index(&self, index: usize) -> Option<BlameHunk> {
         unsafe {

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 use std::marker;
+use std::ptr;
 use std::str;
-use libc;
 
 use {raw, Error, Reference, BranchType, References};
 use util::Binding;
@@ -46,7 +46,7 @@ impl<'repo> Branch<'repo> {
     /// Move/rename an existing local branch reference.
     pub fn rename(&mut self, new_branch_name: &str, force: bool)
                   -> Result<Branch<'repo>, Error> {
-        let mut ret = 0 as *mut raw::git_reference;
+        let mut ret = ptr::null_mut();
         let new_branch_name = try!(CString::new(new_branch_name));
         unsafe {
             try_call!(raw::git_branch_move(&mut ret, self.get().raw(),
@@ -64,7 +64,7 @@ impl<'repo> Branch<'repo> {
 
     /// Return the name of the given local or remote branch.
     pub fn name_bytes(&self) -> Result<&[u8], Error> {
-        let mut ret = 0 as *const libc::c_char;
+        let mut ret = ptr::null();
         unsafe {
             try_call!(raw::git_branch_name(&mut ret, &*self.get().raw()));
             Ok(::opt_bytes(self, ret).unwrap())
@@ -74,7 +74,7 @@ impl<'repo> Branch<'repo> {
     /// Return the reference supporting the remote tracking branch, given a
     /// local branch reference.
     pub fn upstream<'a>(&'a self) -> Result<Branch<'a>, Error> {
-        let mut ret = 0 as *mut raw::git_reference;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_branch_upstream(&mut ret, &*self.get().raw()));
             Ok(Branch::wrap(Binding::from_raw(ret)))
@@ -113,7 +113,7 @@ impl<'repo> Branches<'repo> {
 impl<'repo> Iterator for Branches<'repo> {
     type Item = Result<(Branch<'repo>, BranchType), Error>;
     fn next(&mut self) -> Option<Result<(Branch<'repo>, BranchType), Error>> {
-        let mut ret = 0 as *mut raw::git_reference;
+        let mut ret = ptr::null_mut();
         let mut typ = raw::GIT_BRANCH_LOCAL;
         unsafe {
             try_call_iter!(raw::git_branch_next(&mut ret, &mut typ, self.raw));

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,7 +1,7 @@
 use std::slice;
 use std::str;
+use std::ptr;
 use std::ops::{Deref, DerefMut};
-use libc;
 
 use raw;
 use util::Binding;
@@ -20,7 +20,7 @@ impl Buf {
         ::init();
         unsafe {
             Binding::from_raw(&mut raw::git_buf {
-                ptr: 0 as *mut libc::c_char,
+                ptr: ptr::null_mut(),
                 size: 0,
                 asize: 0,
             } as *mut _)

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -14,6 +14,12 @@ pub struct Buf {
     raw: raw::git_buf,
 }
 
+impl Default for Buf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Buf {
     /// Creates a new empty buffer.
     pub fn new() -> Buf {

--- a/src/build.rs
+++ b/src/build.rs
@@ -54,6 +54,13 @@ pub type Progress<'a> = FnMut(Option<&Path>, usize, usize) + 'a;
 pub type Notify<'a> = FnMut(CheckoutNotificationType, Option<&Path>, DiffFile,
                             DiffFile, DiffFile) -> bool + 'a;
 
+
+impl<'cb> Default for RepoBuilder<'cb> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'cb> RepoBuilder<'cb> {
     /// Creates a new repository builder with all of the default configuration.
     ///
@@ -163,6 +170,12 @@ impl<'cb> RepoBuilder<'cb> {
             try_call!(raw::git_clone(&mut raw, url, into, &opts));
             Ok(Binding::from_raw(raw))
         }
+    }
+}
+
+impl<'cb> Default for CheckoutBuilder<'cb> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -151,16 +151,14 @@ impl<'cb> RepoBuilder<'cb> {
         opts.checkout_opts.checkout_strategy =
             raw::GIT_CHECKOUT_SAFE as c_uint;
 
-        match self.fetch_opts {
-            Some(ref mut cbs) => {
-                opts.fetch_opts = cbs.raw();
-            },
-            None => {}
+        if let Some(ref mut cbs) = self.fetch_opts {
+            opts.fetch_opts = cbs.raw();
         }
 
-        match self.checkout {
-            Some(ref mut c) => unsafe { c.configure(&mut opts.checkout_opts) },
-            None => {}
+        if let Some(ref mut c) = self.checkout {
+            unsafe {
+                c.configure(&mut opts.checkout_opts);
+            }
         }
 
         let url = try!(CString::new(url));
@@ -443,21 +441,17 @@ impl<'cb> CheckoutBuilder<'cb> {
             opts.paths.count = self.path_ptrs.len() as size_t;
         }
 
-        match self.target_dir {
-            Some(ref c) => opts.target_directory = c.as_ptr(),
-            None => {}
+        if let Some(ref c) = self.target_dir {
+            opts.target_directory = c.as_ptr();
         }
-        match self.ancestor_label {
-            Some(ref c) => opts.ancestor_label = c.as_ptr(),
-            None => {}
+        if let Some(ref c) = self.ancestor_label {
+            opts.ancestor_label = c.as_ptr();
         }
-        match self.our_label {
-            Some(ref c) => opts.our_label = c.as_ptr(),
-            None => {}
+        if let Some(ref c) = self.our_label {
+            opts.our_label = c.as_ptr();
         }
-        match self.their_label {
-            Some(ref c) => opts.their_label = c.as_ptr(),
-            None => {}
+        if let Some(ref c) = self.their_label {
+            opts.their_label = c.as_ptr();
         }
         if self.progress.is_some() {
             let f: raw::git_checkout_progress_cb = progress_cb;

--- a/src/build.rs
+++ b/src/build.rs
@@ -3,6 +3,7 @@
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::path::Path;
+use std::ptr;
 use libc::{c_char, size_t, c_void, c_uint, c_int};
 
 use {raw, panic, Error, Repository, FetchOptions, IntoCString};
@@ -133,7 +134,7 @@ impl<'cb> RepoBuilder<'cb> {
         opts.bare = self.bare as c_int;
         opts.checkout_branch = self.branch.as_ref().map(|s| {
             s.as_ptr()
-        }).unwrap_or(0 as *const _);
+        }).unwrap_or(ptr::null());
 
         opts.local = match (self.local, self.hardlinks) {
             (true, false) => raw::GIT_CLONE_LOCAL_NO_LINKS,
@@ -157,7 +158,7 @@ impl<'cb> RepoBuilder<'cb> {
 
         let url = try!(CString::new(url));
         let into = try!(into.into_c_string());
-        let mut raw = 0 as *mut raw::git_repository;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_clone(&mut raw, url, into, &opts));
             Ok(Binding::from_raw(raw))

--- a/src/build.rs
+++ b/src/build.rs
@@ -436,7 +436,7 @@ impl<'cb> CheckoutBuilder<'cb> {
         opts.dir_mode = self.dir_perm.unwrap_or(0) as c_uint;
         opts.file_mode = self.file_perm.unwrap_or(0) as c_uint;
 
-        if self.path_ptrs.len() > 0 {
+        if !self.path_ptrs.is_empty() {
             opts.paths.strings = self.path_ptrs.as_ptr() as *mut _;
             opts.paths.count = self.path_ptrs.len() as size_t;
         }

--- a/src/call.rs
+++ b/src/call.rs
@@ -52,6 +52,8 @@ pub fn last_error(code: libc::c_int) -> Error {
 
 mod impls {
     use std::ffi::CString;
+    use std::ptr;
+
     use libc;
 
     use {raw, ConfigLevel, ResetType, ObjectType, BranchType, Direction};
@@ -81,13 +83,13 @@ mod impls {
 
     impl<T, U: Convert<*const T>> Convert<*const T> for Option<U> {
         fn convert(&self) -> *const T {
-            self.as_ref().map(|s| s.convert()).unwrap_or(0 as *const _)
+            self.as_ref().map(|s| s.convert()).unwrap_or(ptr::null())
         }
     }
 
     impl<T, U: Convert<*mut T>> Convert<*mut T> for Option<U> {
         fn convert(&self) -> *mut T {
-            self.as_ref().map(|s| s.convert()).unwrap_or(0 as *mut _)
+            self.as_ref().map(|s| s.convert()).unwrap_or(ptr::null_mut())
         }
     }
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -1,6 +1,7 @@
 use std::marker;
 use std::mem;
 use std::ops::Range;
+use std::ptr;
 use std::str;
 use libc;
 
@@ -42,7 +43,7 @@ impl<'repo> Commit<'repo> {
 
     /// Get the tree pointed to by a commit.
     pub fn tree(&self) -> Result<Tree<'repo>, Error> {
-        let mut ret = 0 as *mut raw::git_tree;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_commit_tree(&mut ret, &*self.raw));
             Ok(Binding::from_raw(ret))
@@ -210,7 +211,7 @@ impl<'repo> Commit<'repo> {
     /// Use the `parents` iterator to return an iterator over all parents.
     pub fn parent(&self, i: usize) -> Result<Commit<'repo>, Error> {
         unsafe {
-            let mut raw = 0 as *mut raw::git_commit;
+            let mut raw = ptr::null_mut();
             try_call!(raw::git_commit_parent(&mut raw, &*self.raw,
                                              i as libc::c_uint));
             Ok(Binding::from_raw(raw))

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,7 +147,7 @@ impl Config {
             try_call!(raw::git_config_get_bool(&mut out, &*self.raw, name));
 
         }
-        Ok(if out == 0 {false} else {true})
+        Ok(!(out == 0))
     }
 
     /// Get the value of an integer config variable.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 use std::marker;
 use std::path::{Path, PathBuf};
+use std::ptr;
 use std::str;
 use libc;
 
@@ -34,7 +35,7 @@ impl Config {
     /// anything with it.
     pub fn new() -> Result<Config, Error> {
         ::init();
-        let mut raw = 0 as *mut raw::git_config;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_config_new(&mut raw));
             Ok(Binding::from_raw(raw))
@@ -44,7 +45,7 @@ impl Config {
     /// Create a new config instance containing a single on-disk file
     pub fn open(path: &Path) -> Result<Config, Error> {
         ::init();
-        let mut raw = 0 as *mut raw::git_config;
+        let mut raw = ptr::null_mut();
         let path = try!(path.into_c_string());
         unsafe {
             try_call!(raw::git_config_open_ondisk(&mut raw, path));
@@ -59,7 +60,7 @@ impl Config {
     /// be used when accessing default config data outside a repository.
     pub fn open_default() -> Result<Config, Error> {
         ::init();
-        let mut raw = 0 as *mut raw::git_config;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_config_open_default(&mut raw));
             Ok(Binding::from_raw(raw))
@@ -192,7 +193,7 @@ impl Config {
     ///
     /// This method will return an error if this `Config` is not a snapshot.
     pub fn get_bytes(&self, name: &str) -> Result<&[u8], Error> {
-        let mut ret = 0 as *const libc::c_char;
+        let mut ret = ptr::null();
         let name = try!(CString::new(name));
         unsafe {
             try_call!(raw::git_config_get_string(&mut ret, &*self.raw, name));
@@ -226,7 +227,7 @@ impl Config {
 
     /// Get the ConfigEntry for a config variable.
     pub fn get_entry(&self, name: &str) -> Result<ConfigEntry, Error> {
-        let mut ret = 0 as *mut raw::git_config_entry;
+        let mut ret = ptr::null_mut();
         let name = try!(CString::new(name));
         unsafe {
             try_call!(raw::git_config_get_entry(&mut ret, self.raw, name));
@@ -253,7 +254,7 @@ impl Config {
     /// }
     /// ```
     pub fn entries(&self, glob: Option<&str>) -> Result<ConfigEntries, Error> {
-        let mut ret = 0 as *mut raw::git_config_iterator;
+        let mut ret = ptr::null_mut();
         unsafe {
             match glob {
                 Some(s) => {
@@ -277,7 +278,7 @@ impl Config {
     /// shouldn't be used unless the use has created it explicitly. With this
     /// function you'll open the correct one to write to.
     pub fn open_global(&mut self) -> Result<Config, Error> {
-        let mut raw = 0 as *mut raw::git_config;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_config_open_global(&mut raw, self.raw));
             Ok(Binding::from_raw(raw))
@@ -289,7 +290,7 @@ impl Config {
     /// The returned config object can be used to perform get/set/delete
     /// operations on a single specific level.
     pub fn open_level(&self, level: ConfigLevel) -> Result<Config, Error> {
-        let mut raw = 0 as *mut raw::git_config;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_config_open_level(&mut raw, &*self.raw, level));
             Ok(Binding::from_raw(raw))
@@ -355,7 +356,7 @@ impl Config {
     /// you to look into a consistent view of the configuration for looking up
     /// complex values (e.g. a remote, submodule).
     pub fn snapshot(&mut self) -> Result<Config, Error> {
-        let mut ret = 0 as *mut raw::git_config;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_config_snapshot(&mut ret, self.raw));
             Ok(Binding::from_raw(ret))
@@ -476,7 +477,7 @@ impl<'cfg> Binding for ConfigEntries<'cfg> {
 impl<'cfg, 'b> Iterator for &'b ConfigEntries<'cfg> {
     type Item = Result<ConfigEntry<'b>, Error>;
     fn next(&mut self) -> Option<Result<ConfigEntry<'b>, Error>> {
-        let mut raw = 0 as *mut raw::git_config_entry;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call_iter!(raw::git_config_next(&mut raw, self.raw));
             Some(Ok(ConfigEntry {

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -175,7 +175,7 @@ impl CredentialHelper {
             }
             ret.protocol = Some(url.scheme().to_string())
         }
-        return ret;
+        ret
     }
 
     /// Set the username that this credential helper will query with.
@@ -318,7 +318,7 @@ impl CredentialHelper {
         }
         let output = my_try!(p.wait_with_output());
         if !output.status.success() { return (None, None) }
-        return self.parse_output(output.stdout)
+        self.parse_output(output.stdout)
     }
 
     // Parse the output of a command into the username/password found

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -235,9 +235,9 @@ impl CredentialHelper {
             Some(s) => s,
         };
 
-        if cmd.starts_with("!") {
+        if cmd.starts_with('!') {
             self.commands.push(cmd[1..].to_string());
-        } else if cmd.starts_with("/") || cmd.starts_with("\\") ||
+        } else if cmd.starts_with('/') || cmd.starts_with('\\') ||
                   cmd[1..].starts_with(":\\") {
             self.commands.push(format!("\"{}\"", cmd));
         } else {

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -266,7 +266,7 @@ impl CredentialHelper {
         let mut username = self.username.clone();
         let mut password = None;
         for cmd in &self.commands {
-            let (u, p) = self.execute_cmd(&cmd, &username);
+            let (u, p) = self.execute_cmd(cmd, &username);
             if u.is_some() && username.is_none() {
                 username = u;
             }

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -217,12 +217,9 @@ impl CredentialHelper {
     fn config_helper(&mut self, config: &Config) {
         let exact = config.get_string(&self.exact_key("helper"));
         self.add_command(exact.as_ref().ok().map(|s| &s[..]));
-        match self.url_key("helper") {
-            Some(key) => {
-                let url = config.get_string(&key);
-                self.add_command(url.as_ref().ok().map(|s| &s[..]));
-            }
-            None => {}
+        if let Some(key) = self.url_key("helper") {
+            let url = config.get_string(&key);
+            self.add_command(url.as_ref().ok().map(|s| &s[..]));
         }
         let global = config.get_string("credential.helper");
         self.add_command(global.as_ref().ok().map(|s| &s[..]));
@@ -303,17 +300,14 @@ impl CredentialHelper {
         // stdin
         {
             let stdin = p.stdin.as_mut().unwrap();
-            match self.protocol {
-                Some(ref p) => { let _ = writeln!(stdin, "protocol={}", p); }
-                None => {}
+            if let Some(ref p)  = self.protocol {
+                let _ = writeln!(stdin, "protocol={}", p);
             }
-            match self.host {
-                Some(ref p) => { let _ = writeln!(stdin, "host={}", p); }
-                None => {}
+            if let Some(ref p)  = self.host {
+                let _ = writeln!(stdin, "host={}", p);
             }
-            match *username {
-                Some(ref p) => { let _ = writeln!(stdin, "username={}", p); }
-                None => {}
+            if let Some(ref p)  = *username {
+                let _ = writeln!(stdin, "username={}", p);
             }
         }
         let output = my_try!(p.wait_with_output());

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::mem;
 use std::path::Path;
 use std::process::{Command, Stdio};
+use std::ptr;
 use url;
 
 use {raw, Error, Config, IntoCString};
@@ -29,7 +30,7 @@ impl Cred {
     /// or Kerberos authentication.
     pub fn default() -> Result<Cred, Error> {
         ::init();
-        let mut out = 0 as *mut raw::git_cred;
+        let mut out = ptr::null_mut();
         unsafe {
             try_call!(raw::git_cred_default_new(&mut out));
             Ok(Binding::from_raw(out))
@@ -41,7 +42,7 @@ impl Cred {
     /// The username specified is the username to authenticate.
     pub fn ssh_key_from_agent(username: &str) -> Result<Cred, Error> {
         ::init();
-        let mut out = 0 as *mut raw::git_cred;
+        let mut out = ptr::null_mut();
         let username = try!(CString::new(username));
         unsafe {
             try_call!(raw::git_cred_ssh_key_from_agent(&mut out, username));
@@ -59,7 +60,7 @@ impl Cred {
         let publickey = try!(::opt_cstr(publickey));
         let privatekey = try!(privatekey.into_c_string());
         let passphrase = try!(::opt_cstr(passphrase));
-        let mut out = 0 as *mut raw::git_cred;
+        let mut out = ptr::null_mut();
         unsafe {
             try_call!(raw::git_cred_ssh_key_new(&mut out, username, publickey,
                                                 privatekey, passphrase));
@@ -73,7 +74,7 @@ impl Cred {
         ::init();
         let username = try!(CString::new(username));
         let password = try!(CString::new(password));
-        let mut out = 0 as *mut raw::git_cred;
+        let mut out = ptr::null_mut();
         unsafe {
             try_call!(raw::git_cred_userpass_plaintext_new(&mut out, username,
                                                            password));
@@ -112,7 +113,7 @@ impl Cred {
     pub fn username(username: &str) -> Result<Cred, Error> {
         ::init();
         let username = try!(CString::new(username));
-        let mut out = 0 as *mut raw::git_cred;
+        let mut out = ptr::null_mut();
         unsafe {
             try_call!(raw::git_cred_username_new(&mut out, username));
             Ok(Binding::from_raw(out))
@@ -131,7 +132,7 @@ impl Cred {
 
     /// Unwrap access to the underlying raw pointer, canceling the destructor
     pub unsafe fn unwrap(mut self) -> *mut raw::git_cred {
-        mem::replace(&mut self.raw, 0 as *mut raw::git_cred)
+        mem::replace(&mut self.raw, ptr::null_mut())
     }
 }
 

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -265,7 +265,7 @@ impl CredentialHelper {
     pub fn execute(&self) -> Option<(String, String)> {
         let mut username = self.username.clone();
         let mut password = None;
-        for cmd in self.commands.iter() {
+        for cmd in &self.commands {
             let (u, p) = self.execute_cmd(&cmd, &username);
             if u.is_some() && username.is_none() {
                 username = u;

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -1,6 +1,7 @@
 use std::marker;
 use std::mem;
 use std::ffi::CString;
+use std::ptr;
 
 use libc::{c_uint, c_int};
 
@@ -31,7 +32,7 @@ impl<'repo> Describe<'repo> {
     pub fn format(&self, opts: Option<&DescribeFormatOptions>)
                   -> Result<String, Error> {
         let buf = Buf::new();
-        let opts = opts.map(|o| &o.raw as *const _).unwrap_or(0 as *const _);
+        let opts = opts.map(|o| &o.raw as *const _).unwrap_or(ptr::null());
         unsafe {
             try_call!(raw::git_describe_format(buf.raw(), self.raw, opts));
         }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -70,7 +70,7 @@ impl DescribeFormatOptions {
         };
         opts.raw.version = 1;
         opts.raw.abbreviated_size = 7;
-        return opts
+        opts
     }
 
     /// Sets the size of the abbreviated commit id to use.
@@ -113,7 +113,7 @@ impl DescribeOptions {
         };
         opts.raw.version = 1;
         opts.raw.max_candidates_tags = 10;
-        return opts
+        opts
     }
 
     #[allow(missing_docs)]

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -55,6 +55,12 @@ impl<'repo> Drop for Describe<'repo> {
     }
 }
 
+impl Default for DescribeFormatOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DescribeFormatOptions {
     /// Creates a new blank set of formatting options for a description.
     pub fn new() -> DescribeFormatOptions {
@@ -89,6 +95,12 @@ impl DescribeFormatOptions {
         self.dirty_suffix = CString::new(suffix).unwrap();
         self.raw.dirty_suffix = self.dirty_suffix.as_ptr();
         self
+    }
+}
+
+impl Default for DescribeOptions {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -769,6 +769,7 @@ impl<'a> DiffLine<'a> {
     ///  * `B` - Line binary
     pub fn origin(&self) -> char {
         match unsafe { (*self.raw).origin as raw::git_diff_line_t } {
+            raw::GIT_DIFF_LINE_CONTEXT => ' ',
             raw::GIT_DIFF_LINE_ADDITION => '+',
             raw::GIT_DIFF_LINE_DELETION => '-',
             raw::GIT_DIFF_LINE_CONTEXT_EOFNL => '=',

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -433,6 +433,12 @@ impl<'a> Binding for DiffFile<'a> {
     fn raw(&self) -> *const raw::git_diff_file { self.raw }
 }
 
+impl Default for DiffOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DiffOptions {
     /// Creates a new set of empty diff options.
     ///
@@ -954,6 +960,12 @@ impl Binding for DiffBinaryKind {
             DiffBinaryKind::Literal => raw::GIT_DIFF_BINARY_LITERAL,
             DiffBinaryKind::Delta => raw::GIT_DIFF_BINARY_DELTA,
         }
+    }
+}
+
+impl Default for DiffFindOptions {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -769,7 +769,6 @@ impl<'a> DiffLine<'a> {
     ///  * `B` - Line binary
     pub fn origin(&self) -> char {
         match unsafe { (*self.raw).origin as raw::git_diff_line_t } {
-            raw::GIT_DIFF_LINE_CONTEXT => ' ',
             raw::GIT_DIFF_LINE_ADDITION => '+',
             raw::GIT_DIFF_LINE_DELETION => '-',
             raw::GIT_DIFF_LINE_CONTEXT_EOFNL => '=',

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -3,6 +3,7 @@ use std::marker;
 use std::mem;
 use std::ops::Range;
 use std::path::Path;
+use std::ptr;
 use std::slice;
 use libc::{c_char, size_t, c_void, c_int};
 
@@ -206,7 +207,7 @@ impl<'repo> Diff<'repo> {
 
     /// Accumulate diff statistics for all patches.
     pub fn stats(&self) -> Result<DiffStats, Error> {
-        let mut ret = 0 as *mut raw::git_diff_stats;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_diff_get_stats(&mut ret, self.raw));
             Ok(Binding::from_raw(ret))
@@ -689,9 +690,9 @@ impl DiffOptions {
     /// structure is not moved, modified, or used elsewhere.
     pub unsafe fn raw(&mut self) -> *const raw::git_diff_options {
         self.raw.old_prefix = self.old_prefix.as_ref().map(|s| s.as_ptr())
-                                  .unwrap_or(0 as *const _);
+                                  .unwrap_or(ptr::null());
         self.raw.new_prefix = self.new_prefix.as_ref().map(|s| s.as_ptr())
-                                  .unwrap_or(0 as *const _);
+                                  .unwrap_or(ptr::null());
         self.raw.pathspec.count = self.pathspec_ptrs.len() as size_t;
         self.raw.pathspec.strings = self.pathspec_ptrs.as_ptr() as *mut _;
         &self.raw as *const _

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -162,7 +162,7 @@ impl<'repo> Diff<'repo> {
         unsafe {
             try_call!(raw::git_diff_print(self.raw, format, print_cb,
                                           ptr as *mut _));
-            return Ok(())
+            Ok(())
         }
     }
 
@@ -201,7 +201,7 @@ impl<'repo> Diff<'repo> {
             try_call!(raw::git_diff_foreach(self.raw, file_cb_c, binary_cb_c,
                                             hunk_cb_c, line_cb_c,
                                             ptr as *mut _));
-            return Ok(())
+            Ok(())
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,8 @@ impl Error {
     /// Return the error code associated with this error.
     pub fn code(&self) -> ErrorCode {
         match self.raw_code() {
+            raw::GIT_OK => super::ErrorCode::GenericError,
+            raw::GIT_ERROR => super::ErrorCode::GenericError,
             raw::GIT_ENOTFOUND => super::ErrorCode::NotFound,
             raw::GIT_EEXISTS => super::ErrorCode::Exists,
             raw::GIT_EAMBIGUOUS => super::ErrorCode::Ambiguous,
@@ -60,6 +62,8 @@ impl Error {
             raw::GIT_ECONFLICT => super::ErrorCode::Conflict,
             raw::GIT_ELOCKED => super::ErrorCode::Locked,
             raw::GIT_EMODIFIED => super::ErrorCode::Modified,
+            raw::GIT_PASSTHROUGH => super::ErrorCode::GenericError,
+            raw::GIT_ITEROVER => super::ErrorCode::GenericError,
             raw::GIT_EAUTH => super::ErrorCode::Auth,
             raw::GIT_ECERTIFICATE => super::ErrorCode::Certificate,
             raw::GIT_EAPPLIED => super::ErrorCode::Applied,
@@ -75,6 +79,7 @@ impl Error {
     /// Return the error class associated with this error.
     pub fn class(&self) -> ErrorClass {
         match self.raw_class() {
+            raw::GITERR_NONE => super::ErrorClass::None,
             raw::GITERR_NOMEMORY => super::ErrorClass::NoMemory,
             raw::GITERR_OS => super::ErrorClass::Os,
             raw::GITERR_INVALID => super::ErrorClass::Invalid,

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,8 +47,6 @@ impl Error {
     /// Return the error code associated with this error.
     pub fn code(&self) -> ErrorCode {
         match self.raw_code() {
-            raw::GIT_OK => super::ErrorCode::GenericError,
-            raw::GIT_ERROR => super::ErrorCode::GenericError,
             raw::GIT_ENOTFOUND => super::ErrorCode::NotFound,
             raw::GIT_EEXISTS => super::ErrorCode::Exists,
             raw::GIT_EAMBIGUOUS => super::ErrorCode::Ambiguous,
@@ -62,8 +60,6 @@ impl Error {
             raw::GIT_ECONFLICT => super::ErrorCode::Conflict,
             raw::GIT_ELOCKED => super::ErrorCode::Locked,
             raw::GIT_EMODIFIED => super::ErrorCode::Modified,
-            raw::GIT_PASSTHROUGH => super::ErrorCode::GenericError,
-            raw::GIT_ITEROVER => super::ErrorCode::GenericError,
             raw::GIT_EAUTH => super::ErrorCode::Auth,
             raw::GIT_ECERTIFICATE => super::ErrorCode::Certificate,
             raw::GIT_EAPPLIED => super::ErrorCode::Applied,
@@ -79,7 +75,6 @@ impl Error {
     /// Return the error class associated with this error.
     pub fn class(&self) -> ErrorClass {
         match self.raw_class() {
-            raw::GITERR_NONE => super::ErrorClass::None,
             raw::GITERR_NOMEMORY => super::ErrorClass::NoMemory,
             raw::GITERR_OS => super::ErrorClass::Os,
             raw::GITERR_INVALID => super::ErrorClass::Invalid,

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,6 +1,7 @@
 use std::ffi::{CStr, OsString, CString};
 use std::ops::Range;
 use std::path::Path;
+use std::ptr;
 use std::slice;
 
 use libc::{c_int, c_uint, size_t, c_void, c_char};
@@ -56,7 +57,7 @@ impl Index {
     /// used to perform in-memory index operations.
     pub fn new() -> Result<Index, Error> {
         ::init();
-        let mut raw = 0 as *mut raw::git_index;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_index_new(&mut raw));
             Ok(Binding::from_raw(raw))
@@ -73,7 +74,7 @@ impl Index {
     /// on `Repository`.
     pub fn open(index_path: &Path) -> Result<Index, Error> {
         ::init();
-        let mut raw = 0 as *mut raw::git_index;
+        let mut raw = ptr::null_mut();
         let index_path = try!(index_path.into_c_string());
         unsafe {
             try_call!(raw::git_index_open(&mut raw, index_path));
@@ -204,7 +205,7 @@ impl Index {
                                              flag.bits() as c_uint,
                                              callback,
                                              ptr.map(|p| p as *mut _)
-                                                .unwrap_or(0 as *mut _)
+                                                .unwrap_or(ptr::null_mut())
                                                     as *mut c_void));
         }
         return Ok(());
@@ -345,7 +346,7 @@ impl Index {
                                                 &raw_strarray,
                                                 callback,
                                                 ptr.map(|p| p as *mut _)
-                                                   .unwrap_or(0 as *mut _)
+                                                   .unwrap_or(ptr::null_mut())
                                                         as *mut c_void));
         }
         return Ok(());
@@ -380,7 +381,7 @@ impl Index {
                                                 &raw_strarray,
                                                 callback,
                                                 ptr.map(|p| p as *mut _)
-                                                   .unwrap_or(0 as *mut _)
+                                                   .unwrap_or(ptr::null_mut())
                                                         as *mut c_void));
         }
         return Ok(());

--- a/src/index.rs
+++ b/src/index.rs
@@ -208,7 +208,7 @@ impl Index {
                                                 .unwrap_or(ptr::null_mut())
                                                     as *mut c_void));
         }
-        return Ok(());
+        Ok(())
     }
 
     /// Clear the contents (all the entries) of an index object.
@@ -349,7 +349,7 @@ impl Index {
                                                    .unwrap_or(ptr::null_mut())
                                                         as *mut c_void));
         }
-        return Ok(());
+        Ok(())
     }
 
     /// Update all index entries to match the working directory
@@ -384,7 +384,7 @@ impl Index {
                                                    .unwrap_or(ptr::null_mut())
                                                         as *mut c_void));
         }
-        return Ok(());
+        Ok(())
     }
 
     /// Write an existing index object from memory back to disk using an atomic

--- a/src/index.rs
+++ b/src/index.rs
@@ -225,6 +225,11 @@ impl Index {
         unsafe { raw::git_index_entrycount(&*self.raw) as usize }
     }
 
+    /// Return `true` is there is no entry in the index
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get one of the entries in the index by its position.
     pub fn get(&self, n: usize) -> Option<IndexEntry> {
         unsafe {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -28,6 +28,12 @@ impl<'repo> AnnotatedCommit<'repo> {
     }
 }
 
+impl Default for MergeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MergeOptions {
     /// Creates a default set of merge options.
     pub fn new() -> MergeOptions {

--- a/src/message.rs
+++ b/src/message.rs
@@ -25,7 +25,7 @@ fn _message_prettify(message: CString, comment_char: Option<u8>)
 }
 
 /// The default comment character for message_prettify ('#')
-pub const DEFAULT_COMMENT_CHAR: Option<u8> = Some('#' as u8);
+pub const DEFAULT_COMMENT_CHAR: Option<u8> = Some(b'#');
 
 #[cfg(test)]
 mod tests {

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,7 +6,7 @@ use {raw, Buf, Error, IntoCString};
 use util::Binding;
 
 /// Clean up a message, removing extraneous whitespace, and ensure that the
-/// message ends with a newline. If comment_char is Some, also remove comment
+/// message ends with a newline. If `comment_char` is `Some`, also remove comment
 /// lines starting with that character.
 pub fn message_prettify<T: IntoCString>(message: T, comment_char: Option<u8>)
                                         -> Result<String, Error> {
@@ -24,7 +24,7 @@ fn _message_prettify(message: CString, comment_char: Option<u8>)
     Ok(ret.as_str().unwrap().to_string())
 }
 
-/// The default comment character for message_prettify ('#')
+/// The default comment character for `message_prettify` ('#')
 pub const DEFAULT_COMMENT_CHAR: Option<u8> = Some(b'#');
 
 #[cfg(test)]

--- a/src/object.rs
+++ b/src/object.rs
@@ -35,7 +35,7 @@ impl<'repo> Object<'repo> {
     /// peeled until the type changes (e.g. a tag will be chased until the
     /// referenced object is no longer a tag).
     pub fn peel(&self, kind: ObjectType) -> Result<Object<'repo>, Error> {
-        let mut raw = 0 as *mut raw::git_object;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_object_peel(&mut raw, &*self.raw(), kind));
             Ok(Binding::from_raw(raw))
@@ -117,7 +117,7 @@ impl<'repo> Object<'repo> {
     /// Performs a describe operation on this commitish object.
     pub fn describe(&self, opts: &DescribeOptions)
                     -> Result<Describe, Error> {
-        let mut ret = 0 as *mut _;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_describe_commit(&mut ret, self.raw, opts.raw()));
             Ok(Binding::from_raw(ret))
@@ -149,7 +149,7 @@ impl<'repo> Object<'repo> {
 
 impl<'repo> Clone for Object<'repo> {
     fn clone(&self) -> Object<'repo> {
-        let mut raw = 0 as *mut raw::git_object;
+        let mut raw = ptr::null_mut();
         unsafe {
             let rc = raw::git_object_dup(&mut raw, self.raw);
             assert_eq!(rc, 0);

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -8,7 +8,7 @@ use {raw, Error};
 use util::Binding;
 
 /// Unique identity of any object (commit, tree, blob, tag).
-#[derive(Copy)]
+#[derive(Copy, Clone)]
 pub struct Oid {
     raw: raw::git_oid,
 }
@@ -114,10 +114,6 @@ impl Ord for Oid {
             _ => Ordering::Greater,
         }
     }
-}
-
-impl Clone for Oid {
-    fn clone(&self) -> Oid { *self }
 }
 
 impl Hash for Oid {

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -1,4 +1,4 @@
-//! Bindings to libgit2's raw git_strarray type
+//! Bindings to libgit2's raw `git_strarray` type
 
 use std::ops::Deref;
 

--- a/src/packbuilder.rs
+++ b/src/packbuilder.rs
@@ -6,7 +6,7 @@ use libc::{c_int, c_uint, c_void, size_t};
 use {raw, panic, Repository, Error, Oid, Revwalk, Buf};
 use util::Binding;
 
-/// Stages that are reported by the PackBuilder progress callback.
+/// Stages that are reported by the `PackBuilder` progress callback.
 pub enum PackBuilderStage {
     /// Adding objects to the pack
     AddingObjects,

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -40,7 +40,7 @@ pub fn wrap<T, F: FnOnce() -> T>(f: F) -> Option<T> {
     let mut bomb = Bomb { enabled: true };
     let ret = Some(f());
     bomb.enabled = false;
-    return ret;
+    ret
 }
 
 pub fn check() {

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::ptr;
 use libc::{c_char, c_int, c_void};
 
 use {raw, Blob, Buf, Diff, DiffDelta, DiffHunk, DiffLine, DiffOptions, Error};
@@ -33,7 +34,7 @@ impl Patch {
     ///
     /// Returns Ok(None) for an unchanged or binary file.
     pub fn from_diff(diff: &Diff, idx: usize) -> Result<Option<Patch>, Error> {
-        let mut ret = 0 as *mut raw::git_patch;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_patch_from_diff(&mut ret, diff.raw(), idx));
             Ok(Binding::from_raw_opt(ret))
@@ -48,7 +49,7 @@ impl Patch {
                       opts: Option<&mut DiffOptions>)
                       -> Result<Patch, Error>
     {
-        let mut ret = 0 as *mut raw::git_patch;
+        let mut ret = ptr::null_mut();
         let old_path = try!(into_opt_c_string(old_path));
         let new_path = try!(into_opt_c_string(new_path));
         unsafe {
@@ -70,7 +71,7 @@ impl Patch {
                                 opts: Option<&mut DiffOptions>)
                                 -> Result<Patch, Error>
     {
-        let mut ret = 0 as *mut raw::git_patch;
+        let mut ret = ptr::null_mut();
         let old_path = try!(into_opt_c_string(old_path));
         let new_path = try!(into_opt_c_string(new_path));
         unsafe {
@@ -93,7 +94,7 @@ impl Patch {
                         opts: Option<&mut DiffOptions>)
                         -> Result<Patch, Error>
     {
-        let mut ret = 0 as *mut raw::git_patch;
+        let mut ret = ptr::null_mut();
         let old_path = try!(into_opt_c_string(old_path));
         let new_path = try!(into_opt_c_string(new_path));
         unsafe {
@@ -139,7 +140,7 @@ impl Patch {
 
     /// Get a DiffHunk and its total line count from the Patch.
     pub fn hunk(&mut self, hunk_idx: usize) -> Result<(DiffHunk, usize), Error> {
-        let mut ret = 0 as *const raw::git_diff_hunk;
+        let mut ret = ptr::null();
         let mut lines = 0;
         unsafe {
             try_call!(raw::git_patch_get_hunk(&mut ret, &mut lines, self.raw, hunk_idx));
@@ -158,7 +159,7 @@ impl Patch {
     pub fn line_in_hunk(&mut self,
                         hunk_idx: usize,
                         line_of_hunk: usize) -> Result<DiffLine, Error> {
-        let mut ret = 0 as *const raw::git_diff_line;
+        let mut ret = ptr::null();
         unsafe {
             try_call!(raw::git_patch_get_line_in_hunk(&mut ret,
                                                       self.raw,

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -187,7 +187,7 @@ impl Patch {
         let ptr = &mut line_cb as *mut _ as *mut c_void;
         unsafe {
             try_call!(raw::git_patch_print(self.raw, print_cb, ptr));
-            return Ok(())
+            Ok(())
         }
     }
 

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -2,6 +2,7 @@ use std::iter::IntoIterator;
 use std::marker;
 use std::ops::Range;
 use std::path::Path;
+use std::ptr;
 use libc::size_t;
 
 use {raw, Error, Diff, Tree, PathspecFlags, Index, Repository, DiffDelta, IntoCString};
@@ -43,7 +44,7 @@ impl Pathspec {
                      where T: IntoCString, I: IntoIterator<Item=T> {
         let (_a, _b, arr) = try!(::util::iter2cstrs(specs));
         unsafe {
-            let mut ret = 0 as *mut raw::git_pathspec;
+            let mut ret = ptr::null_mut();
             try_call!(raw::git_pathspec_new(&mut ret, &arr));
             Ok(Binding::from_raw(ret))
         }
@@ -57,7 +58,7 @@ impl Pathspec {
     /// specified.
     pub fn match_diff(&self, diff: &Diff, flags: PathspecFlags)
                       -> Result<PathspecMatchList, Error> {
-        let mut ret = 0 as *mut raw::git_pathspec_match_list;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_pathspec_match_diff(&mut ret, diff.raw(),
                                                    flags.bits(), self.raw));
@@ -73,7 +74,7 @@ impl Pathspec {
     /// specified.
     pub fn match_tree(&self, tree: &Tree, flags: PathspecFlags)
                       -> Result<PathspecMatchList, Error> {
-        let mut ret = 0 as *mut raw::git_pathspec_match_list;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_pathspec_match_tree(&mut ret, tree.raw(),
                                                    flags.bits(), self.raw));
@@ -89,7 +90,7 @@ impl Pathspec {
     /// specified.
     pub fn match_index(&self, index: &Index, flags: PathspecFlags)
                        -> Result<PathspecMatchList, Error> {
-        let mut ret = 0 as *mut raw::git_pathspec_match_list;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_pathspec_match_index(&mut ret, index.raw(),
                                                     flags.bits(), self.raw));
@@ -111,7 +112,7 @@ impl Pathspec {
     /// specified.
     pub fn match_workdir(&self, repo: &Repository, flags: PathspecFlags)
                          -> Result<PathspecMatchList, Error> {
-        let mut ret = 0 as *mut raw::git_pathspec_match_list;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_pathspec_match_workdir(&mut ret, repo.raw(),
                                                       flags.bits(), self.raw));

--- a/src/proxy_options.rs
+++ b/src/proxy_options.rs
@@ -6,6 +6,7 @@ use raw;
 use util::Binding;
 
 /// Options which can be specified to various fetch operations.
+#[derive(Default)]
 pub struct ProxyOptions<'a> {
     url: Option<CString>,
     proxy_kind: raw::git_proxy_t,
@@ -15,11 +16,7 @@ pub struct ProxyOptions<'a> {
 impl<'a> ProxyOptions<'a> {
     /// Creates a new set of proxy options ready to be configured.
     pub fn new() -> ProxyOptions<'a> {
-        ProxyOptions {
-            url: None,
-            proxy_kind: raw::GIT_PROXY_NONE,
-            _marker: marker::PhantomData,
-        }
+        Default::default()
     }
 
     /// Try to auto-detect the proxy from the git configuration.

--- a/src/proxy_options.rs
+++ b/src/proxy_options.rs
@@ -1,5 +1,6 @@
 use std::ffi::CString;
 use std::marker;
+use std::ptr;
 
 use raw;
 use util::Binding;
@@ -49,10 +50,10 @@ impl<'a> Binding for ProxyOptions<'a> {
         raw::git_proxy_options {
             version: raw::GIT_PROXY_OPTIONS_VERSION,
             kind: self.proxy_kind,
-            url: self.url.as_ref().map(|s| s.as_ptr()).unwrap_or(0 as *const _),
+            url: self.url.as_ref().map(|s| s.as_ptr()).unwrap_or(ptr::null()),
             credentials: None,
             certificate_check: None,
-            payload: 0 as *mut _,
+            payload: ptr::null_mut(),
         }
     }
 }

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -2,8 +2,8 @@ use std::cmp::Ordering;
 use std::ffi::CString;
 use std::marker;
 use std::mem;
+use std::ptr;
 use std::str;
-use libc;
 
 use {raw, Error, Oid, Repository, Object, ObjectType};
 use util::Binding;
@@ -142,7 +142,7 @@ impl<'repo> Reference<'repo> {
     /// If a direct reference is passed as an argument, a copy of that
     /// reference is returned.
     pub fn resolve(&self) -> Result<Reference<'repo>, Error> {
-        let mut raw = 0 as *mut raw::git_reference;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_reference_resolve(&mut raw, &*self.raw));
             Ok(Binding::from_raw(raw))
@@ -154,7 +154,7 @@ impl<'repo> Reference<'repo> {
     /// This method recursively peels the reference until it reaches
     /// an object of the specified type.
     pub fn peel(&self, kind: ObjectType) -> Result<Object<'repo>, Error> {
-        let mut raw = 0 as *mut raw::git_object;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_reference_peel(&mut raw, self.raw, kind));
             Ok(Binding::from_raw(raw))
@@ -169,7 +169,7 @@ impl<'repo> Reference<'repo> {
     /// the given name, the renaming will fail.
     pub fn rename(&mut self, new_name: &str, force: bool,
                   msg: &str) -> Result<Reference<'repo>, Error> {
-        let mut raw = 0 as *mut raw::git_reference;
+        let mut raw = ptr::null_mut();
         let new_name = try!(CString::new(new_name));
         let msg = try!(CString::new(msg));
         unsafe {
@@ -187,7 +187,7 @@ impl<'repo> Reference<'repo> {
     /// reference.
     pub fn set_target(&mut self, id: Oid, reflog_msg: &str)
                       -> Result<Reference<'repo>, Error> {
-        let mut raw = 0 as *mut raw::git_reference;
+        let mut raw = ptr::null_mut();
         let msg = try!(CString::new(reflog_msg));
         unsafe {
             try_call!(raw::git_reference_set_target(&mut raw, self.raw,
@@ -261,7 +261,7 @@ impl<'repo> Binding for References<'repo> {
 impl<'repo> Iterator for References<'repo> {
     type Item = Result<Reference<'repo>, Error>;
     fn next(&mut self) -> Option<Result<Reference<'repo>, Error>> {
-        let mut out = 0 as *mut raw::git_reference;
+        let mut out = ptr::null_mut();
         unsafe {
             try_call_iter!(raw::git_reference_next(&mut out, self.raw));
             Some(Ok(Binding::from_raw(out)))
@@ -278,7 +278,7 @@ impl<'repo> Drop for References<'repo> {
 impl<'repo> Iterator for ReferenceNames<'repo> {
     type Item = Result<&'repo str, Error>;
     fn next(&mut self) -> Option<Result<&'repo str, Error>> {
-        let mut out = 0 as *const libc::c_char;
+        let mut out = ptr::null();
         unsafe {
             try_call_iter!(raw::git_reference_next_name(&mut out,
                                                         self.inner.raw));

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -66,6 +66,11 @@ impl Reflog {
         unsafe { raw::git_reflog_entrycount(self.raw) as usize }
     }
 
+    /// Return `true ` is there is no log entry in a reflog
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get an iterator to all entries inside of this reflog
     pub fn iter(&self) -> ReflogIter {
         ReflogIter { range: 0..self.len(), reflog: self }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -2,6 +2,7 @@ use std::ffi::CString;
 use std::ops::Range;
 use std::marker;
 use std::mem;
+use std::ptr;
 use std::slice;
 use std::str;
 use libc;
@@ -110,9 +111,9 @@ impl<'repo> Remote<'repo> {
         // TODO: can callbacks be exposed safely?
         unsafe {
             try_call!(raw::git_remote_connect(self.raw, dir,
-                                              0 as *const _,
-                                              0 as *const _,
-                                              0 as *const _));
+                                              ptr::null(),
+                                              ptr::null(),
+                                              ptr::null()));
         }
         Ok(())
     }
@@ -132,7 +133,7 @@ impl<'repo> Remote<'repo> {
             try_call!(raw::git_remote_connect(self.raw, dir,
                                               &cb.raw(),
                                               &proxy_options.raw(),
-                                              0 as *const _));
+                                              ptr::null()));
         }
 
         Ok(RemoteConnection {
@@ -271,7 +272,7 @@ impl<'repo> Remote<'repo> {
     /// the remote is initiated and it remains available after disconnecting.
     pub fn list(&self) -> Result<&[RemoteHead], Error> {
         let mut size = 0;
-        let mut base = 0 as *mut _;
+        let mut base = ptr::null_mut();
         unsafe {
             try_call!(raw::git_remote_ls(&mut base, &mut size, self.raw));
             assert_eq!(mem::size_of::<RemoteHead>(),
@@ -303,7 +304,7 @@ impl<'repo> Remote<'repo> {
 
 impl<'repo> Clone for Remote<'repo> {
     fn clone(&self) -> Remote<'repo> {
-        let mut ret = 0 as *mut raw::git_remote;
+        let mut ret = ptr::null_mut();
         let rc = unsafe { call!(raw::git_remote_dup(&mut ret, self.raw)) };
         assert_eq!(rc, 0);
         Remote {
@@ -437,7 +438,7 @@ impl<'cb> Binding for FetchOptions<'cb> {
             // TODO: expose this as a builder option
             custom_headers: raw::git_strarray {
                 count: 0,
-                strings: 0 as *mut _,
+                strings: ptr::null_mut(),
             },
         }
     }
@@ -494,7 +495,7 @@ impl<'cb> Binding for PushOptions<'cb> {
             // TODO: expose this as a builder option
             custom_headers: raw::git_strarray {
                 count: 0,
-                strings: 0 as *mut _,
+                strings: ptr::null_mut(),
             },
         }
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -500,8 +500,9 @@ impl<'cb> Binding for PushOptions<'cb> {
     fn raw(&self) -> raw::git_push_options {
         raw::git_push_options {
             version: 1,
-            callbacks: self.callbacks.as_ref().map(|m| m.raw())
-                           .unwrap_or(RemoteCallbacks::new().raw()),
+            callbacks: self.callbacks.as_ref()
+                           .map(|m| m.raw())
+                           .unwrap_or_else(|| RemoteCallbacks::new().raw()),
             proxy_opts: self.proxy.as_ref().map(|m| m.raw())
                             .unwrap_or_else(|| ProxyOptions::new().raw()),
             pb_parallelism: self.pb_parallelism as libc::c_uint,

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -127,8 +127,8 @@ impl<'repo> Remote<'repo> {
                                           proxy_options: Option<ProxyOptions<'cb>>)
                     -> Result<RemoteConnection<'repo, 'connection, 'cb>, Error> {
 
-        let cb = Box::new(cb.unwrap_or_else(|| RemoteCallbacks::new()));
-        let proxy_options = proxy_options.unwrap_or_else(|| ProxyOptions::new());
+        let cb = Box::new(cb.unwrap_or_else(RemoteCallbacks::new));
+        let proxy_options = proxy_options.unwrap_or_else(ProxyOptions::new);
         unsafe {
             try_call!(raw::git_remote_connect(self.raw, dir,
                                               &cb.raw(),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -371,6 +371,12 @@ impl<'remote> RemoteHead<'remote> {
     }
 }
 
+impl<'cb> Default for FetchOptions<'cb> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'cb> FetchOptions<'cb> {
     /// Creates a new blank set of fetch options
     pub fn new() -> FetchOptions<'cb> {
@@ -441,6 +447,13 @@ impl<'cb> Binding for FetchOptions<'cb> {
                 strings: ptr::null_mut(),
             },
         }
+    }
+}
+
+
+impl<'cb> Default for PushOptions<'cb> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -77,6 +77,12 @@ pub type CertificateCheck<'a> = FnMut(&Cert, &str) -> bool + 'a;
 /// was rejected by the remote server with a reason why.
 pub type PushUpdateReference<'a> = FnMut(&str, Option<&str>) -> Result<(), Error> + 'a;
 
+impl<'a> Default for RemoteCallbacks<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> RemoteCallbacks<'a> {
     /// Creates a new set of empty callbacks
     pub fn new() -> RemoteCallbacks<'a> {

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -192,7 +192,7 @@ impl<'a> Binding for RemoteCallbacks<'a> {
                 callbacks.update_tips = Some(f);
             }
             callbacks.payload = self as *const _ as *mut _;
-            return callbacks;
+            callbacks
         }
     }
 }

--- a/src/remote_callbacks.rs
+++ b/src/remote_callbacks.rs
@@ -2,6 +2,7 @@ use std::ffi::CStr;
 use std::marker;
 use std::mem;
 use std::slice;
+use std::ptr;
 use std::str;
 use libc::{c_void, c_int, c_char, c_uint};
 
@@ -258,7 +259,7 @@ extern fn credentials_cb(ret: *mut *mut raw::git_cred,
             let payload = &mut *(payload as *mut RemoteCallbacks);
             let callback = try!(payload.credentials.as_mut()
                                        .ok_or(raw::GIT_PASSTHROUGH as c_int));
-            *ret = 0 as *mut raw::git_cred;
+            *ret = ptr::null_mut();
             let url = try!(str::from_utf8(CStr::from_ptr(url).to_bytes())
                               .map_err(|_| raw::GIT_PASSTHROUGH as c_int));
             let username_from_url = match ::opt_bytes(&url, username_from_url) {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1751,7 +1751,7 @@ impl Repository {
         unsafe {
             let mut raw_oid = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
             let message = try!(CString::new(message));
-            let flags = flags.unwrap_or(StashFlags::empty());
+            let flags = flags.unwrap_or_else(StashFlags::empty);
             try_call!(raw::git_stash_save(&mut raw_oid,
                                           self.raw(),
                                           stasher.raw(),

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1240,9 +1240,8 @@ impl Repository {
             let mut raw_opts = mem::zeroed();
             try_call!(raw::git_checkout_init_options(&mut raw_opts,
                                 raw::GIT_CHECKOUT_OPTIONS_VERSION));
-            match opts {
-                Some(c) => c.configure(&mut raw_opts),
-                None => {}
+            if let Some(c) = opts {
+                c.configure(&mut raw_opts);
             }
 
             try_call!(raw::git_checkout_index(self.raw,
@@ -1261,9 +1260,8 @@ impl Repository {
             let mut raw_opts = mem::zeroed();
             try_call!(raw::git_checkout_init_options(&mut raw_opts,
                                 raw::GIT_CHECKOUT_OPTIONS_VERSION));
-            match opts {
-                Some(c) => c.configure(&mut raw_opts),
-                None => {}
+            if let Some(c) = opts {
+                c.configure(&mut raw_opts);
             }
 
             try_call!(raw::git_checkout_tree(self.raw, &*treeish.raw(),

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1973,7 +1973,7 @@ impl RepositoryInitOptions {
         opts.template_path = ::call::convert(&self.template_path);
         opts.initial_head = ::call::convert(&self.initial_head);
         opts.origin_url = ::call::convert(&self.origin_url);
-        return opts;
+        opts
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,6 +1,7 @@
 use std::ffi::CString;
 use std::marker;
 use std::mem;
+use std::ptr;
 use std::str;
 use std::fmt;
 use libc;
@@ -29,7 +30,7 @@ impl<'a> Signature<'a> {
     /// See `new` for more information
     pub fn now(name: &str, email: &str) -> Result<Signature<'static>, Error> {
         ::init();
-        let mut ret = 0 as *mut raw::git_signature;
+        let mut ret = ptr::null_mut();
         let name = try!(CString::new(name));
         let email = try!(CString::new(email));
         unsafe {
@@ -47,7 +48,7 @@ impl<'a> Signature<'a> {
     pub fn new(name: &str, email: &str, time: &Time)
                -> Result<Signature<'static>, Error> {
         ::init();
-        let mut ret = 0 as *mut raw::git_signature;
+        let mut ret = ptr::null_mut();
         let name = try!(CString::new(name));
         let email = try!(CString::new(email));
         unsafe {
@@ -128,7 +129,7 @@ impl Clone for Signature<'static> {
     fn clone(&self) -> Signature<'static> {
         // TODO: can this be defined for 'a and just do a plain old copy if the
         //       lifetime isn't static?
-        let mut raw = 0 as *mut raw::git_signature;
+        let mut raw = ptr::null_mut();
         let rc = unsafe { raw::git_signature_dup(&mut raw, &*self.raw) };
         assert_eq!(rc, 0);
         unsafe { Binding::from_raw(raw) }

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -106,7 +106,6 @@ pub extern fn stash_cb(index: size_t,
 
 fn convert_progress(progress: raw::git_stash_apply_progress_t) -> StashApplyProgress {
     match progress {
-        raw::GIT_STASH_APPLY_PROGRESS_NONE => StashApplyProgress::None,
         raw::GIT_STASH_APPLY_PROGRESS_LOADING_STASH => StashApplyProgress::LoadingStash,
         raw::GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX => StashApplyProgress::AnalyzeIndex,
         raw::GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED => StashApplyProgress::AnalyzeModified,

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -106,6 +106,7 @@ pub extern fn stash_cb(index: size_t,
 
 fn convert_progress(progress: raw::git_stash_apply_progress_t) -> StashApplyProgress {
     match progress {
+        raw::GIT_STASH_APPLY_PROGRESS_NONE => StashApplyProgress::None,
         raw::GIT_STASH_APPLY_PROGRESS_LOADING_STASH => StashApplyProgress::LoadingStash,
         raw::GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX => StashApplyProgress::AnalyzeIndex,
         raw::GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED => StashApplyProgress::AnalyzeModified,

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -23,6 +23,12 @@ pub struct StashApplyOptions<'cb> {
     raw_opts: raw::git_stash_apply_options
 }
 
+impl<'cb> Default for StashApplyOptions<'cb> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'cb> StashApplyOptions<'cb> {
     /// Creates a default set of merge options.
     pub fn new() -> StashApplyOptions<'cb> {

--- a/src/status.rs
+++ b/src/status.rs
@@ -258,6 +258,11 @@ impl<'repo> Statuses<'repo> {
         unsafe { raw::git_status_list_entrycount(self.raw) as usize }
     }
 
+    /// Return `true` is there is not status entry in this list.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns an iterator over the statuses in this list.
     pub fn iter(&self) -> StatusIter {
         StatusIter {

--- a/src/status.rs
+++ b/src/status.rs
@@ -58,6 +58,12 @@ pub struct StatusEntry<'statuses> {
     _marker: marker::PhantomData<&'statuses DiffDelta<'statuses>>,
 }
 
+impl Default for StatusOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl StatusOptions {
     /// Creates a new blank set of status options.
     pub fn new() -> StatusOptions {

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -1,4 +1,4 @@
-//! Bindings to libgit2's raw git_strarray type
+//! Bindings to libgit2's raw `git_strarray` type
 
 use std::str;
 use std::ops::Range;

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -61,6 +61,9 @@ impl StringArray {
 
     /// Returns the number of strings in this array.
     pub fn len(&self) -> usize { self.raw.count as usize }
+
+    /// Return `true` if this array is empty.
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl Binding for StringArray {

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -1,4 +1,5 @@
 use std::marker;
+use std::ptr;
 use std::str;
 use std::path::Path;
 
@@ -108,7 +109,7 @@ impl<'repo> Submodule<'repo> {
     /// This will only work if the submodule is checked out into the working
     /// directory.
     pub fn open(&self) -> Result<Repository, Error> {
-        let mut raw = 0 as *mut raw::git_repository;
+        let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_submodule_open(&mut raw, self.raw));
             Ok(Binding::from_raw(raw))

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,5 +1,6 @@
 use std::marker;
 use std::mem;
+use std::ptr;
 use std::str;
 
 use {raw, signature, Error, Oid, Object, Signature, ObjectType};
@@ -47,7 +48,7 @@ impl<'repo> Tag<'repo> {
 
     /// Recursively peel a tag until a non tag git_object is found
     pub fn peel(&self) -> Result<Object<'repo>, Error> {
-        let mut ret = 0 as *mut raw::git_object;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_tag_peel(&mut ret, &*self.raw));
             Ok(Binding::from_raw(ret))
@@ -73,7 +74,7 @@ impl<'repo> Tag<'repo> {
     /// This method performs a repository lookup for the given object and
     /// returns it
     pub fn target(&self) -> Result<Object<'repo>, Error> {
-        let mut ret = 0 as *mut raw::git_object;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_tag_target(&mut ret, &*self.raw));
             Ok(Binding::from_raw(ret))

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::io;
+use std::ptr;
 use tempdir::TempDir;
 use url::Url;
 
@@ -48,7 +49,7 @@ pub fn realpath(original: &Path) -> io::Result<PathBuf> {
     }
     unsafe {
         let cstr = try!(CString::new(original.as_os_str().as_bytes()));
-        let ptr = realpath(cstr.as_ptr(), 0 as *mut _);
+        let ptr = realpath(cstr.as_ptr(), ptr::null_mut());
         if ptr.is_null() {
             return Err(io::Error::last_os_error())
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::io;
+#[cfg(unix)]
 use std::ptr;
 use tempdir::TempDir;
 use url::Url;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -5,6 +5,7 @@ use std::io::prelude::*;
 use std::io;
 use std::mem;
 use std::slice;
+use std::ptr;
 use std::str;
 use libc::{c_int, c_void, c_uint, c_char, size_t};
 
@@ -134,7 +135,7 @@ impl Transport {
                     subtransport: S) -> Result<Transport, Error>
         where S: SmartSubtransport
     {
-        let mut ret = 0 as *mut _;
+        let mut ret = ptr::null_mut();
 
         let mut raw = Box::new(RawSmartSubtransport {
             raw: raw::git_smart_subtransport {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -290,7 +290,7 @@ extern fn stream_read(stream: *mut raw::git_smart_subtransport_stream,
     });
     match ret {
         Some(Ok(_)) => 0,
-        Some(Err(e)) => unsafe { set_err(e); -2 },
+        Some(Err(e)) => unsafe { set_err(&e); -2 },
         None => -1,
     }
 }
@@ -307,12 +307,12 @@ extern fn stream_write(stream: *mut raw::git_smart_subtransport_stream,
     });
     match ret {
         Some(Ok(())) => 0,
-        Some(Err(e)) => unsafe { set_err(e); -2 },
+        Some(Err(e)) => unsafe { set_err(&e); -2 },
         None => -1,
     }
 }
 
-unsafe fn set_err(e: io::Error) {
+unsafe fn set_err(e: &io::Error) {
     let s = CString::new(e.to_string()).unwrap();
     raw::giterr_set_str(raw::GITERR_NET as c_int, s.as_ptr())
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -44,6 +44,11 @@ impl<'repo> Tree<'repo> {
         unsafe { raw::git_tree_entrycount(&*self.raw) as usize }
     }
 
+    /// Return `true` if there is not entry
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns an iterator over the entries in this tree.
     pub fn iter(&self) -> TreeIter {
         TreeIter { range: 0..self.len(), tree: self }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,6 +4,7 @@ use std::ffi::CString;
 use std::ops::Range;
 use std::marker;
 use std::path::Path;
+use std::ptr;
 use std::str;
 use libc;
 
@@ -90,7 +91,7 @@ impl<'repo> Tree<'repo> {
     /// given its relative path.
     pub fn get_path(&self, path: &Path) -> Result<TreeEntry<'static>, Error> {
         let path = try!(path.into_c_string());
-        let mut ret = 0 as *mut raw::git_tree_entry;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_tree_entry_bypath(&mut ret, &*self.raw(), path));
             Ok(Binding::from_raw(ret))
@@ -172,7 +173,7 @@ impl<'tree> TreeEntry<'tree> {
     /// Convert a tree entry to the object it points to.
     pub fn to_object<'a>(&self, repo: &'a Repository)
                          -> Result<Object<'a>, Error> {
-        let mut ret = 0 as *mut raw::git_object;
+        let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_tree_entry_to_object(&mut ret, repo.raw(),
                                                     &*self.raw()));
@@ -221,7 +222,7 @@ impl<'a> Binding for TreeEntry<'a> {
 
 impl<'a> Clone for TreeEntry<'a> {
     fn clone(&self) -> TreeEntry<'a> {
-        let mut ret = 0 as *mut raw::git_tree_entry;
+        let mut ret = ptr::null_mut();
         unsafe {
             assert_eq!(raw::git_tree_entry_dup(&mut ret, &*self.raw()), 0);
             Binding::from_raw(ret)

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -23,6 +23,11 @@ impl<'repo> TreeBuilder<'repo> {
         unsafe { raw::git_treebuilder_entrycount(self.raw) as usize }
     }
 
+    /// Return `true` if there is no entry
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get en entry from the builder from its filename
     pub fn get<P>(&self, filename: P) -> Result<Option<TreeEntry>, Error>
         where P: IntoCString

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -1,4 +1,5 @@
 use std::marker;
+use std::ptr;
 
 use libc::{c_int, c_void};
 
@@ -49,7 +50,7 @@ impl<'repo> TreeBuilder<'repo> {
         let filename = try!(filename.into_c_string());
         let filemode = filemode as raw::git_filemode_t;
 
-        let mut ret = 0 as *const raw::git_tree_entry;
+        let mut ret = ptr::null();
         unsafe {
             try_call!(raw::git_treebuilder_insert(&mut ret, self.raw, filename,
                                                   oid.raw(), filemode));


### PR DESCRIPTION
This fixes a bunch of clippy warnings. I grouped by warning to make it easier to review, let me know if you'd like to me split it another way.

- 51c93566d2ff78957e73b5752da705082f4a308a converts all `0 as *mut` into `ptr::null_mut()` and `0 as *const` into `ptr::null()`. I didn't change the `0 as *mut *mut T` into `ptr_null_mut()` because I was not sure is that was really equivalent.

- I'm not 100% sure about acd17f996a40470d5495c3cde55007fa5b1e5034: maybe the `&& false` was on purpose? In that case, we should probably add a comment explaining why though.

- I'm not sure about 5f0c936e2eca230d639cce720e35deaabbb40344. I mean, it looks fine to me, but maybe there is a good reason for not deriving `Clone`?

There are still a few warnings, but it compiles without warning with:
```cargo clippy -- -A many_single_char_names -A useless_let_if_seq -A cyclomatic_complexity -A needless_lifetimes -A should_implement_trait -A new_without_default_derive -A zero_ptr -A wrong_self_convention```

I'm tempted to address the `needless_lifetimes` warnings but I'm not too sure about changing the signature of unsafe function/methods in some cases.