### PR TITLE
Added function to clone a repository recursively

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -197,7 +197,7 @@ impl Repository {
     /// Update submodules recursively.
     ///
     /// Uninitialized submodules will be initialized.
-    pub fn update_submodules(&self) -> Result<(), Error> {
+    fn update_submodules(&self) -> Result<(), Error> {
 
         fn add_subrepos(repo: &Repository, list: &mut Vec<Repository>)
                         -> Result<(), Error> {


### PR DESCRIPTION
It is similar to `git clone --recursive`. The current implementation is very
simple and limited as it does not allow to customize the fetch and checkout
tasks and submodules are processed sequentially (i.e. no option like `--jobs`
to process them concurrently).

Addressing the limitations described above requires some thought:

- `FetchOptions` and `CheckoutBuilder` are not `Send`.
- Should different submodules have different options?
- Are new options and callbacks needed?

I ended up creating repositories with recursive submodules and thought a simple implementation was better than none for now, especially for build scripts. `RepoBuilder` can be extended in the future to allow customizing the recursive cloning operation.

**Note**: One improvement I may be able to do now to this PR is updating submodules concurrently. I would need to add a dependency on rayon or crossbeam to git2. Just let me know if you want me to do it.

Thank you.