### PR TITLE
Implement IntoIter for StringArray

### DIFF
--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -74,6 +74,14 @@ impl Binding for StringArray {
     fn raw(&self) -> raw::git_strarray { self.raw }
 }
 
+impl<'a> IntoIterator for &'a StringArray {
+    type Item = Option<&'a str>;
+    type IntoIter = Iter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl<'a> Iterator for Iter<'a> {
     type Item = Option<&'a str>;
     fn next(&mut self) -> Option<Option<&'a str>> {


### PR DESCRIPTION
This is mainly for syntax sugar:

```rust
let strarray: StringArray = get_array();
for str in strarray {
    println!("{}", str);
}