### PR TITLE
Odb foreach bindings

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1419,6 +1419,8 @@ pub type git_stash_cb = extern fn(index: size_t,
 pub type git_packbuilder_foreach_cb = extern fn(*const c_void, size_t,
                                                 *mut c_void) -> c_int;
 
+pub type git_odb_foreach_cb = extern fn(id: *const git_oid, payload: *mut c_void) -> c_int;
+
 extern {
     // threads
     pub fn git_libgit2_init() -> c_int;
@@ -1470,7 +1472,7 @@ extern {
                                    start_path: *const c_char,
                                    across_fs: c_int,
                                    ceiling_dirs: *const c_char) -> c_int;
-    
+
     // revparse
     pub fn git_revparse(revspec: *mut git_revspec,
                         repo: *mut git_repository,
@@ -2671,6 +2673,7 @@ extern {
     pub fn git_odb_stream_finalize_write(id: *mut git_oid,
                                          stream: *mut git_odb_stream) -> c_int;
     pub fn git_odb_stream_free(stream: *mut git_odb_stream);
+    pub fn git_odb_foreach(db: *mut git_odb, cb: git_odb_foreach_cb, payload: *mut c_void) -> c_int;
 }
 
 pub fn init() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,6 +545,7 @@ mod merge;
 mod message;
 mod note;
 mod object;
+mod odb;
 mod oid;
 mod packbuilder;
 mod pathspec;
@@ -566,7 +567,6 @@ mod tag;
 mod time;
 mod tree;
 mod treebuilder;
-mod odb;
 
 fn init() {
     static INIT: Once = ONCE_INIT;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -13,8 +13,7 @@ use {Branches, BranchType, Index, Config, Oid, Blob, BlobWriter, Branch, Commit,
 use {AnnotatedCommit, MergeOptions, SubmoduleIgnore, SubmoduleStatus, MergeAnalysis, MergePreference};
 use {ObjectType, Tag, Note, Notes, StatusOptions, Statuses, Status, Revwalk};
 use {RevparseMode, RepositoryInitMode, Reflog, IntoCString, Describe};
-use {DescribeOptions, TreeBuilder, Diff, DiffOptions, PackBuilder};
-use {Odb};
+use {DescribeOptions, TreeBuilder, Diff, DiffOptions, PackBuilder, Odb};
 use build::{RepoBuilder, CheckoutBuilder};
 use stash::{StashApplyOptions, StashCbData, stash_cb};
 use string_array::StringArray;


### PR DESCRIPTION
Bindings for git_odb_foreach.

I noticed that much of this is duplicated in #240, so just the foreach call and callback should probably be rebased on that code first if there is interest in merging this.