### PR TITLE
Add git_merge_trees bindings

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2263,6 +2263,12 @@ extern {
                              our_commit: *const git_commit,
                              their_commit: *const git_commit,
                              opts: *const git_merge_options) -> c_int;
+    pub fn git_merge_trees(out: *mut *mut git_index,
+                           repo: *mut git_repository,
+                           ancestor_tree: *const git_tree,
+                           our_tree: *const git_tree,
+                           their_tree: *const git_tree,
+                           opts: *const git_merge_options) -> c_int;
     pub fn git_repository_state_cleanup(repo: *mut git_repository) -> c_int;
 
     // merge analysis

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1391,6 +1391,21 @@ impl Repository {
         }
     }
 
+    /// Merge two trees, producing an index that reflects the result of
+    /// the merge. The index may be written as-is to the working directory or
+    /// checked out. If the index is to be converted to a tree, the caller
+    /// should resolve any conflicts that arose as part of the merge.
+    pub fn merge_trees(&self, ancestor_tree: &Tree, our_tree: &Tree,
+                       their_tree: &Tree, opts: Option<&MergeOptions>) -> Result<Index, Error> {
+        let mut raw = ptr::null_mut();
+        unsafe {
+            try_call!(raw::git_merge_trees(&mut raw, self.raw, ancestor_tree.raw(),
+                                           our_tree.raw(), their_tree.raw(),
+                                           opts.map(|o| o.raw())));
+            Ok(Binding::from_raw(raw))
+        }
+    }
+
     /// Remove all the metadata associated with an ongoing command like merge,
     /// revert, cherry-pick, etc. For example: MERGE_HEAD, MERGE_MSG, etc.
     pub fn cleanup_state(&self) -> Result<(), Error> {


### PR DESCRIPTION
I guess it can be workaround by creating dummy commits but it should be more straightforward. 