### PR TITLE
Fix incorrect cast resulting in panic

### DIFF
--- a/src/reference.rs
+++ b/src/reference.rs
@@ -167,7 +167,7 @@ impl<'repo> Reference<'repo> {
     /// This method recursively peels the reference until it reaches
     /// a blob.
     pub fn peel_to_blob(&self) -> Result<Blob<'repo>, Error> {
-        try!(self.peel(ObjectType::Blob)).cast_or_panic(ObjectType::Blob)
+        Ok(try!(self.peel(ObjectType::Blob)).cast_or_panic(ObjectType::Blob))
     }
 
     /// Peel a reference to a commit
@@ -175,7 +175,7 @@ impl<'repo> Reference<'repo> {
     /// This method recursively peels the reference until it reaches
     /// a blob.
     pub fn peel_to_commit(&self) -> Result<Commit<'repo>, Error> {
-        try!(self.peel(ObjectType::Commit)).cast_or_panic(ObjectType::Commit)
+        Ok(try!(self.peel(ObjectType::Commit)).cast_or_panic(ObjectType::Commit))
     }
 
     /// Peel a reference to a tree
@@ -183,7 +183,7 @@ impl<'repo> Reference<'repo> {
     /// This method recursively peels the reference until it reaches
     /// a blob.
     pub fn peel_to_tree(&self) -> Result<Tree<'repo>, Error> {
-        try!(self.peel(ObjectType::Tree)).cast_or_panic(ObjectType::Tree)
+        Ok(try!(self.peel(ObjectType::Tree)).cast_or_panic(ObjectType::Tree))
     }
 
     /// Peel a reference to a tag
@@ -191,7 +191,7 @@ impl<'repo> Reference<'repo> {
     /// This method recursively peels the reference until it reaches
     /// a tag.
     pub fn peel_to_tag(&self) -> Result<Tag<'repo>, Error> {
-        try!(self.peel(ObjectType::Tag)).cast_or_panic(ObjectType::Tag)
+        Ok(try!(self.peel(ObjectType::Tag)).cast_or_panic(ObjectType::Tag))
     }
 
     /// Rename an existing reference.


### PR DESCRIPTION
Small bug in references causing panics because of unmatched size (I might have more rust-way casts soon)