### PR TITLE
Implement Sync for git2::Repository

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -36,6 +36,7 @@ pub struct Repository {
 // It is the current belief that a `Repository` can be sent among threads, or
 // even shared among threads in a mutex.
 unsafe impl Send for Repository {}
+unsafe impl Sync for Repository {}
 
 /// Options which can be used to configure how a repository is initialized
 pub struct RepositoryInitOptions {


### PR DESCRIPTION
git2::Repository already implements Send, which is required for multiple
readers across different threads.  However, both the comment above that
implementation, as well as the comments in libgit2 itself seem to
indicate that the underlying datastructures themselves, can be sync'd,
not just sent.

This has a practical application in cases when trying to share a
Repository instances inside an Iron handler, for example.