### PR TITLE
Clippy and rustfmt-nightly

### DIFF
--- a/examples/add.rs
+++ b/examples/add.rs
@@ -15,8 +15,8 @@
 #![deny(warnings)]
 #![allow(trivial_casts)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
@@ -39,15 +39,19 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     let cb = &mut |path: &Path, _matched_spec: &[u8]| -> i32 {
         let status = repo.status_file(path).unwrap();
 
-        let ret = if status.contains(git2::STATUS_WT_MODIFIED) ||
-                     status.contains(git2::STATUS_WT_NEW) {
-            println!("add '{}'", path.display());
-            0
-        } else {
-            1
-        };
+        let ret =
+            if status.contains(git2::STATUS_WT_MODIFIED) || status.contains(git2::STATUS_WT_NEW) {
+                println!("add '{}'", path.display());
+                0
+            } else {
+                1
+            };
 
-        if args.flag_dry_run {1} else {ret}
+        if args.flag_dry_run {
+            1
+        } else {
+            ret
+        }
     };
     let cb = if args.flag_verbose || args.flag_update {
         Some(cb as &mut git2::IndexMatchedPath)
@@ -76,8 +80,9 @@ Options:
     -h, --help          show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/blame.rs
+++ b/examples/blame.rs
@@ -12,17 +12,18 @@
  * <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use docopt::Docopt;
-use git2::{Repository, BlameOptions};
+use git2::{BlameOptions, Repository};
 use std::path::Path;
-use std::io::{BufReader, BufRead};
+use std::io::{BufRead, BufReader};
 
-#[derive(Deserialize)] #[allow(non_snake_case)]
+#[derive(Deserialize)]
+#[allow(non_snake_case)]
 struct Args {
     arg_path: String,
     arg_spec: Option<String>,
@@ -45,7 +46,6 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     // Parse spec
     if let Some(spec) = args.arg_spec.as_ref() {
-
         let revspec = try!(repo.revparse(spec));
 
         let (oldest, newest) = if revspec.mode().contains(git2::REVPARSE_SINGLE) {
@@ -66,7 +66,6 @@ fn run(args: &Args) -> Result<(), git2::Error> {
                 commit_id = format!("{}", commit.id())
             }
         }
-
     }
 
     let spec = format!("{}:{}", commit_id, path.display());
@@ -76,11 +75,15 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     let reader = BufReader::new(blob.content());
 
     for (i, line) in reader.lines().enumerate() {
-        if let (Ok(line), Some(hunk)) = (line, blame.get_line(i+1)) {
+        if let (Ok(line), Some(hunk)) = (line, blame.get_line(i + 1)) {
             let sig = hunk.final_signature();
-            println!("{} {} <{}> {}", hunk.final_commit_id(),
-                     String::from_utf8_lossy(sig.name_bytes()),
-                     String::from_utf8_lossy(sig.email_bytes()), line);
+            println!(
+                "{} {} <{}> {}",
+                hunk.final_commit_id(),
+                String::from_utf8_lossy(sig.name_bytes()),
+                String::from_utf8_lossy(sig.email_bytes()),
+                line
+            );
         }
     }
 
@@ -97,8 +100,9 @@ Options:
     -F                  follow only the first parent commits
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/cat-file.rs
+++ b/examples/cat-file.rs
@@ -14,15 +14,15 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use std::io::{self, Write};
 
 use docopt::Docopt;
-use git2::{Repository, ObjectType, Blob, Commit, Signature, Tag, Tree};
+use git2::{Blob, Commit, ObjectType, Repository, Signature, Tag, Tree};
 
 #[derive(Deserialize)]
 struct Args {
@@ -63,9 +63,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
             Some(ObjectType::Tree) => {
                 show_tree(obj.as_tree().unwrap());
             }
-            Some(ObjectType::Any) | None => {
-                println!("unknown {}", obj.id())
-            }
+            Some(ObjectType::Any) | None => println!("unknown {}", obj.id()),
         }
     }
     Ok(())
@@ -100,22 +98,37 @@ fn show_tag(tag: &Tag) {
 
 fn show_tree(tree: &Tree) {
     for entry in tree.iter() {
-        println!("{:06o} {} {}\t{}",
-                 entry.filemode(),
-                 entry.kind().unwrap().str(),
-                 entry.id(),
-                 entry.name().unwrap());
+        println!(
+            "{:06o} {} {}\t{}",
+            entry.filemode(),
+            entry.kind().unwrap().str(),
+            entry.id(),
+            entry.name().unwrap()
+        );
     }
 }
 
 fn show_sig(header: &str, sig: Option<Signature>) {
-    let sig = match sig { Some(s) => s, None => return };
+    let sig = match sig {
+        Some(s) => s,
+        None => return,
+    };
     let offset = sig.when().offset_minutes();
-    let (sign, offset) = if offset < 0 {('-', -offset)} else {('+', offset)};
+    let (sign, offset) = if offset < 0 {
+        ('-', -offset)
+    } else {
+        ('+', offset)
+    };
     let (hours, minutes) = (offset / 60, offset % 60);
-    println!("{} {} {} {}{:02}{:02}",
-             header, sig, sig.when().seconds(), sign, hours, minutes);
-
+    println!(
+        "{} {} {} {}{:02}{:02}",
+        header,
+        sig,
+        sig.when().seconds(),
+        sign,
+        hours,
+        minutes
+    );
 }
 
 fn main() {
@@ -133,8 +146,9 @@ Options:
     -h, --help          show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/clone.rs
+++ b/examples/clone.rs
@@ -14,14 +14,14 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use docopt::Docopt;
-use git2::build::{RepoBuilder, CheckoutBuilder};
-use git2::{RemoteCallbacks, Progress, FetchOptions};
+use git2::build::{CheckoutBuilder, RepoBuilder};
+use git2::{FetchOptions, Progress, RemoteCallbacks};
 use std::cell::RefCell;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -55,19 +55,31 @@ fn print(state: &mut State) {
             println!("");
             state.newline = true;
         }
-        print!("Resolving deltas {}/{}\r", stats.indexed_deltas(),
-               stats.total_deltas());
+        print!(
+            "Resolving deltas {}/{}\r",
+            stats.indexed_deltas(),
+            stats.total_deltas()
+        );
     } else {
-        print!("net {:3}% ({:4} kb, {:5}/{:5})  /  idx {:3}% ({:5}/{:5})  \
-                /  chk {:3}% ({:4}/{:4}) {}\r",
-               network_pct, kbytes, stats.received_objects(),
-               stats.total_objects(),
-               index_pct, stats.indexed_objects(), stats.total_objects(),
-               co_pct, state.current, state.total,
-               state.path
-                    .as_ref()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .unwrap_or_default())
+        print!(
+            "net {:3}% ({:4} kb, {:5}/{:5})  /  idx {:3}% ({:5}/{:5})  \
+             /  chk {:3}% ({:4}/{:4}) {}\r",
+            network_pct,
+            kbytes,
+            stats.received_objects(),
+            stats.total_objects(),
+            index_pct,
+            stats.indexed_objects(),
+            stats.total_objects(),
+            co_pct,
+            state.current,
+            state.total,
+            state
+                .path
+                .as_ref()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        )
     }
     io::stdout().flush().unwrap();
 }
@@ -99,8 +111,12 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
     let mut fo = FetchOptions::new();
     fo.remote_callbacks(cb);
-    try!(RepoBuilder::new().fetch_options(fo).with_checkout(co)
-                           .clone(&args.arg_url, Path::new(&args.arg_path)));
+    try!(
+        RepoBuilder::new()
+            .fetch_options(fo)
+            .with_checkout(co)
+            .clone(&args.arg_url, Path::new(&args.arg_path))
+    );
     println!("");
 
     Ok(())
@@ -114,11 +130,11 @@ Options:
     -h, --help          show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),
     }
 }
-

--- a/examples/diff.rs
+++ b/examples/diff.rs
@@ -14,18 +14,19 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use std::str;
 
 use docopt::Docopt;
-use git2::{Repository, Error, Object, ObjectType, DiffOptions, Diff};
+use git2::{Diff, DiffOptions, Error, Object, ObjectType, Repository};
 use git2::{DiffFindOptions, DiffFormat};
 
-#[derive(Deserialize)] #[allow(non_snake_case)]
+#[derive(Deserialize)]
+#[allow(non_snake_case)]
 struct Args {
     arg_from_oid: Option<String>,
     arg_to_oid: Option<String>,
@@ -70,7 +71,11 @@ const GREEN: &'static str = "\u{1b}[32m";
 const CYAN: &'static str = "\u{1b}[36m";
 
 #[derive(PartialEq, Eq, Copy, Clone)]
-enum Cache { Normal, Only, None }
+enum Cache {
+    Normal,
+    Only,
+    None,
+}
 
 fn run(args: &Args) -> Result<(), Error> {
     let path = args.flag_git_dir.as_ref().map(|s| &s[..]).unwrap_or(".");
@@ -87,11 +92,21 @@ fn run(args: &Args) -> Result<(), Error> {
         .include_untracked(args.flag_untracked)
         .patience(args.flag_patience)
         .minimal(args.flag_minimal);
-    if let Some(amt) = args.flag_unified { opts.context_lines(amt); }
-    if let Some(amt) = args.flag_inter_hunk_context { opts.interhunk_lines(amt); }
-    if let Some(amt) = args.flag_abbrev { opts.id_abbrev(amt); }
-    if let Some(ref s) = args.flag_src_prefix { opts.old_prefix(&s); }
-    if let Some(ref s) = args.flag_dst_prefix { opts.new_prefix(&s); }
+    if let Some(amt) = args.flag_unified {
+        opts.context_lines(amt);
+    }
+    if let Some(amt) = args.flag_inter_hunk_context {
+        opts.interhunk_lines(amt);
+    }
+    if let Some(amt) = args.flag_abbrev {
+        opts.id_abbrev(amt);
+    }
+    if let Some(ref s) = args.flag_src_prefix {
+        opts.old_prefix(&s);
+    }
+    if let Some(ref s) = args.flag_dst_prefix {
+        opts.new_prefix(&s);
+    }
     if let Some("diff-index") = args.flag_format.as_ref().map(|s| &s[..]) {
         opts.id_abbrev(40);
     }
@@ -101,10 +116,11 @@ fn run(args: &Args) -> Result<(), Error> {
     let t2 = try!(tree_to_treeish(&repo, args.arg_to_oid.as_ref()));
     let head = try!(tree_to_treeish(&repo, Some(&"HEAD".to_string()))).unwrap();
     let mut diff = match (t1, t2, args.cache()) {
-        (Some(t1), Some(t2), _) => {
-            try!(repo.diff_tree_to_tree(t1.as_tree(), t2.as_tree(),
-                                        Some(&mut opts)))
-        }
+        (Some(t1), Some(t2), _) => try!(repo.diff_tree_to_tree(
+            t1.as_tree(),
+            t2.as_tree(),
+            Some(&mut opts)
+        )),
         (t1, None, Cache::None) => {
             let t1 = t1.unwrap_or(head);
             try!(repo.diff_tree_to_workdir(t1.as_tree(), Some(&mut opts)))
@@ -114,18 +130,15 @@ fn run(args: &Args) -> Result<(), Error> {
             try!(repo.diff_tree_to_index(t1.as_tree(), None, Some(&mut opts)))
         }
         (Some(t1), None, _) => {
-            try!(repo.diff_tree_to_workdir_with_index(t1.as_tree(),
-                                                      Some(&mut opts)))
+            try!(repo.diff_tree_to_workdir_with_index(t1.as_tree(), Some(&mut opts)))
         }
-        (None, None, _) => {
-            try!(repo.diff_index_to_workdir(None, Some(&mut opts)))
-        }
+        (None, None, _) => try!(repo.diff_index_to_workdir(None, Some(&mut opts))),
         (None, Some(_), _) => unreachable!(),
     };
 
     // Apply rename and copy detection if requested
-    if args.flag_break_rewrites || args.flag_find_copies_harder ||
-       args.flag_find_renames.is_some() || args.flag_find_copies.is_some()
+    if args.flag_break_rewrites || args.flag_find_copies_harder || args.flag_find_renames.is_some()
+        || args.flag_find_copies.is_some()
     {
         let mut opts = DiffFindOptions::new();
         if let Some(t) = args.flag_find_renames {
@@ -142,13 +155,14 @@ fn run(args: &Args) -> Result<(), Error> {
     }
 
     // Generate simple output
-    let stats = args.flag_stat | args.flag_numstat | args.flag_shortstat |
-                args.flag_summary;
+    let stats = args.flag_stat | args.flag_numstat | args.flag_shortstat | args.flag_summary;
     if stats {
         try!(print_stats(&diff, args));
     }
     if args.flag_patch || !stats {
-        if args.color() { print!("{}", RESET); }
+        if args.color() {
+            print!("{}", RESET);
+        }
         let mut last_color = None;
         try!(diff.print(args.diff_format(), |_delta, _hunk, line| {
             if args.color() {
@@ -159,7 +173,7 @@ fn run(args: &Args) -> Result<(), Error> {
                     '<' => Some(RED),
                     'F' => Some(BOLD),
                     'H' => Some(CYAN),
-                    _ => None
+                    _ => None,
                 };
                 if args.color() && next != last_color {
                     if last_color == Some(BOLD) || next == Some(BOLD) {
@@ -177,7 +191,9 @@ fn run(args: &Args) -> Result<(), Error> {
             print!("{}", str::from_utf8(line.content()).unwrap());
             true
         }));
-        if args.color() { print!("{}", RESET); }
+        if args.color() {
+            print!("{}", RESET);
+        }
     }
 
     Ok(())
@@ -203,9 +219,14 @@ fn print_stats(diff: &Diff, args: &Args) -> Result<(), Error> {
     Ok(())
 }
 
-fn tree_to_treeish<'a>(repo: &'a Repository, arg: Option<&String>)
-                       -> Result<Option<Object<'a>>, Error> {
-    let arg = match arg { Some(s) => s, None => return Ok(None) };
+fn tree_to_treeish<'a>(
+    repo: &'a Repository,
+    arg: Option<&String>,
+) -> Result<Option<Object<'a>>, Error> {
+    let arg = match arg {
+        Some(s) => s,
+        None => return Ok(None),
+    };
     let obj = try!(repo.revparse_single(arg));
     let tree = try!(obj.peel(ObjectType::Tree));
     Ok(Some(tree))
@@ -213,17 +234,27 @@ fn tree_to_treeish<'a>(repo: &'a Repository, arg: Option<&String>)
 
 impl Args {
     fn cache(&self) -> Cache {
-        if self.flag_cached {Cache::Only}
-        else if self.flag_nocached {Cache::None}
-        else {Cache::Normal}
+        if self.flag_cached {
+            Cache::Only
+        } else if self.flag_nocached {
+            Cache::None
+        } else {
+            Cache::Normal
+        }
     }
-    fn color(&self) -> bool { self.flag_color && !self.flag_no_color }
+    fn color(&self) -> bool {
+        self.flag_color && !self.flag_no_color
+    }
     fn diff_format(&self) -> DiffFormat {
-        if self.flag_patch {DiffFormat::Patch}
-        else if self.flag_name_only {DiffFormat::NameOnly}
-        else if self.flag_name_status {DiffFormat::NameStatus}
-        else if self.flag_raw {DiffFormat::Raw}
-        else {
+        if self.flag_patch {
+            DiffFormat::Patch
+        } else if self.flag_name_only {
+            DiffFormat::NameOnly
+        } else if self.flag_name_status {
+            DiffFormat::NameStatus
+        } else if self.flag_raw {
+            DiffFormat::Raw
+        } else {
             match self.flag_format.as_ref().map(|s| &s[..]) {
                 Some("name") => DiffFormat::NameOnly,
                 Some("name-status") => DiffFormat::NameStatus,
@@ -275,8 +306,9 @@ Options:
     -h, --help                  show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/fetch.rs
+++ b/examples/fetch.rs
@@ -14,13 +14,13 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use docopt::Docopt;
-use git2::{Repository, RemoteCallbacks, AutotagOption, FetchOptions};
+use git2::{AutotagOption, FetchOptions, RemoteCallbacks, Repository};
 use std::io::{self, Write};
 use std::str;
 
@@ -36,9 +36,10 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     // Figure out whether it's a named remote or a URL
     println!("Fetching {} for repo", remote);
     let mut cb = RemoteCallbacks::new();
-    let mut remote = try!(repo.find_remote(remote).or_else(|_| {
-        repo.remote_anonymous(remote)
-    }));
+    let mut remote = try!(
+        repo.find_remote(remote)
+            .or_else(|_| { repo.remote_anonymous(remote) })
+    );
     cb.sideband_progress(|data| {
         print!("remote: {}", str::from_utf8(data).unwrap());
         io::stdout().flush().unwrap();
@@ -62,14 +63,19 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     // the download rate.
     cb.transfer_progress(|stats| {
         if stats.received_objects() == stats.total_objects() {
-            print!("Resolving deltas {}/{}\r", stats.indexed_deltas(),
-                   stats.total_deltas());
+            print!(
+                "Resolving deltas {}/{}\r",
+                stats.indexed_deltas(),
+                stats.total_deltas()
+            );
         } else if stats.total_objects() > 0 {
-            print!("Received {}/{} objects ({}) in {} bytes\r",
-                   stats.received_objects(),
-                   stats.total_objects(),
-                   stats.indexed_objects(),
-                   stats.received_bytes());
+            print!(
+                "Received {}/{} objects ({}) in {} bytes\r",
+                stats.received_objects(),
+                stats.total_objects(),
+                stats.indexed_objects(),
+                stats.received_bytes()
+            );
         }
         io::stdout().flush().unwrap();
         true
@@ -87,14 +93,21 @@ fn run(args: &Args) -> Result<(), git2::Error> {
         // how many objects we saved from having to cross the network.
         let stats = remote.stats();
         if stats.local_objects() > 0 {
-            println!("\rReceived {}/{} objects in {} bytes (used {} local \
-                      objects)", stats.indexed_objects(),
-                     stats.total_objects(), stats.received_bytes(),
-                     stats.local_objects());
+            println!(
+                "\rReceived {}/{} objects in {} bytes (used {} local \
+                 objects)",
+                stats.indexed_objects(),
+                stats.total_objects(),
+                stats.received_bytes(),
+                stats.local_objects()
+            );
         } else {
-            println!("\rReceived {}/{} objects in {} bytes",
-                     stats.indexed_objects(), stats.total_objects(),
-                     stats.received_bytes());
+            println!(
+                "\rReceived {}/{} objects in {} bytes",
+                stats.indexed_objects(),
+                stats.total_objects(),
+                stats.received_bytes()
+            );
         }
     }
 
@@ -105,8 +118,12 @@ fn run(args: &Args) -> Result<(), git2::Error> {
     // commits. This may be needed even if there was no packfile to download,
     // which can happen e.g. when the branches have been changed but all the
     // needed objects are available locally.
-    try!(remote.update_tips(None, true,
-                            AutotagOption::Unspecified, None));
+    try!(remote.update_tips(
+        None,
+        true,
+        AutotagOption::Unspecified,
+        None
+    ));
 
     Ok(())
 }
@@ -119,8 +136,9 @@ Options:
     -h, --help          show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -14,16 +14,16 @@
 
 #![deny(warnings)]
 
-#[macro_use]
-extern crate serde_derive;
 extern crate docopt;
 extern crate git2;
+#[macro_use]
+extern crate serde_derive;
 extern crate time;
 
 use std::str;
 use docopt::Docopt;
-use git2::{Repository, Signature, Commit, ObjectType, Time, DiffOptions};
-use git2::{Pathspec, Error, DiffFormat};
+use git2::{Commit, DiffOptions, ObjectType, Repository, Signature, Time};
+use git2::{DiffFormat, Error, Pathspec};
 
 #[derive(Deserialize)]
 struct Args {
@@ -53,19 +53,25 @@ fn run(args: &Args) -> Result<(), Error> {
     let mut revwalk = try!(repo.revwalk());
 
     // Prepare the revwalk based on CLI parameters
-    let base = if args.flag_reverse {git2::SORT_REVERSE} else {git2::SORT_NONE};
-    revwalk.set_sorting(base | if args.flag_topo_order {
-        git2::SORT_TOPOLOGICAL
-    } else if args.flag_date_order {
-        git2::SORT_TIME
+    let base = if args.flag_reverse {
+        git2::SORT_REVERSE
     } else {
         git2::SORT_NONE
-    });
+    };
+    revwalk.set_sorting(
+        base | if args.flag_topo_order {
+            git2::SORT_TOPOLOGICAL
+        } else if args.flag_date_order {
+            git2::SORT_TIME
+        } else {
+            git2::SORT_NONE
+        },
+    );
     for commit in &args.arg_commit {
         if commit.starts_with('^') {
             let obj = try!(repo.revparse_single(&commit[1..]));
             try!(revwalk.hide(obj.id()));
-            continue
+            continue;
         }
         let revspec = try!(repo.revparse(commit));
         if revspec.mode().contains(git2::REVPARSE_SINGLE) {
@@ -98,41 +104,60 @@ fn run(args: &Args) -> Result<(), Error> {
     macro_rules! filter_try {
         ($e:expr) => (match $e { Ok(t) => t, Err(e) => return Some(Err(e)) })
     }
-    let revwalk = revwalk.filter_map(|id| {
-        let id = filter_try!(id);
-        let commit = filter_try!(repo.find_commit(id));
-        let parents = commit.parents().len();
-        if parents < args.min_parents() { return None }
-        if let Some(n) = args.max_parents() {
-            if parents >= n { return None }
-        }
-        if !args.arg_spec.is_empty() {
-            match commit.parents().len() {
-                0 => {
-                    let tree = filter_try!(commit.tree());
-                    let flags = git2::PATHSPEC_NO_MATCH_ERROR;
-                    if ps.match_tree(&tree, flags).is_err() { return None }
-                }
-                _ => {
-                    let m = commit.parents().all(|parent| {
-                        match_with_parent(&repo, &commit, &parent, &mut diffopts)
-                                        .unwrap_or(false)
-                    });
-                    if !m { return None }
+    let revwalk = revwalk
+        .filter_map(|id| {
+            let id = filter_try!(id);
+            let commit = filter_try!(repo.find_commit(id));
+            let parents = commit.parents().len();
+            if parents < args.min_parents() {
+                return None;
+            }
+            if let Some(n) = args.max_parents() {
+                if parents >= n {
+                    return None;
                 }
             }
-        }
-        if !sig_matches(&commit.author(), &args.flag_author) { return None }
-        if !sig_matches(&commit.committer(), &args.flag_committer) { return None }
-        if !log_message_matches(commit.message(), &args.flag_grep) { return None }
-        Some(Ok(commit))
-    }).skip(args.flag_skip.unwrap_or(0)).take(args.flag_max_count.unwrap_or(!0));
+            if !args.arg_spec.is_empty() {
+                match commit.parents().len() {
+                    0 => {
+                        let tree = filter_try!(commit.tree());
+                        let flags = git2::PATHSPEC_NO_MATCH_ERROR;
+                        if ps.match_tree(&tree, flags).is_err() {
+                            return None;
+                        }
+                    }
+                    _ => {
+                        let m = commit.parents().all(|parent| {
+                            match_with_parent(&repo, &commit, &parent, &mut diffopts)
+                                .unwrap_or(false)
+                        });
+                        if !m {
+                            return None;
+                        }
+                    }
+                }
+            }
+            if !sig_matches(&commit.author(), &args.flag_author) {
+                return None;
+            }
+            if !sig_matches(&commit.committer(), &args.flag_committer) {
+                return None;
+            }
+            if !log_message_matches(commit.message(), &args.flag_grep) {
+                return None;
+            }
+            Some(Ok(commit))
+        })
+        .skip(args.flag_skip.unwrap_or(0))
+        .take(args.flag_max_count.unwrap_or(!0));
 
     // print!
     for commit in revwalk {
         let commit = try!(commit);
         print_commit(&commit);
-        if !args.flag_patch || commit.parents().len() > 1 { continue }
+        if !args.flag_patch || commit.parents().len() > 1 {
+            continue;
+        }
         let a = if commit.parents().len() == 1 {
             let parent = try!(commit.parent(0));
             Some(try!(parent.tree()))
@@ -140,8 +165,11 @@ fn run(args: &Args) -> Result<(), Error> {
             None
         };
         let b = try!(commit.tree());
-        let diff = try!(repo.diff_tree_to_tree(a.as_ref(), Some(&b),
-                                               Some(&mut diffopts2)));
+        let diff = try!(repo.diff_tree_to_tree(
+            a.as_ref(),
+            Some(&b),
+            Some(&mut diffopts2)
+        ));
         try!(diff.print(DiffFormat::Patch, |_delta, _hunk, line| {
             match line.origin() {
                 ' ' | '+' | '-' => print!("{}", line.origin()),
@@ -158,10 +186,10 @@ fn run(args: &Args) -> Result<(), Error> {
 fn sig_matches(sig: &Signature, arg: &Option<String>) -> bool {
     match *arg {
         Some(ref s) => {
-            sig.name().map(|n| n.contains(s)).unwrap_or(false) ||
-                sig.email().map(|n| n.contains(s)).unwrap_or(false)
+            sig.name().map(|n| n.contains(s)).unwrap_or(false)
+                || sig.email().map(|n| n.contains(s)).unwrap_or(false)
         }
-        None => true
+        None => true,
     }
 }
 
@@ -201,17 +229,25 @@ fn print_time(time: &Time, prefix: &str) {
         n => (n, '+'),
     };
     let (hours, minutes) = (offset / 60, offset % 60);
-    let ts = time::Timespec::new(time.seconds() +
-                                 (time.offset_minutes() as i64) * 60, 0);
+    let ts = time::Timespec::new(time.seconds() + (time.offset_minutes() as i64) * 60, 0);
     let time = time::at(ts);
 
-    println!("{}{} {}{:02}{:02}", prefix,
-             time.strftime("%a %b %e %T %Y").unwrap(), sign, hours, minutes);
-
+    println!(
+        "{}{} {}{:02}{:02}",
+        prefix,
+        time.strftime("%a %b %e %T %Y").unwrap(),
+        sign,
+        hours,
+        minutes
+    );
 }
 
-fn match_with_parent(repo: &Repository, commit: &Commit, parent: &Commit,
-                     opts: &mut DiffOptions) -> Result<bool, Error> {
+fn match_with_parent(
+    repo: &Repository,
+    commit: &Commit,
+    parent: &Commit,
+    opts: &mut DiffOptions,
+) -> Result<bool, Error> {
     let a = try!(parent.tree());
     let b = try!(commit.tree());
     let diff = try!(repo.diff_tree_to_tree(Some(&a), Some(&b), Some(opts)));
@@ -220,13 +256,19 @@ fn match_with_parent(repo: &Repository, commit: &Commit, parent: &Commit,
 
 impl Args {
     fn min_parents(&self) -> usize {
-        if self.flag_no_min_parents { return 0 }
-        self.flag_min_parents.unwrap_or(if self.flag_merges {2} else {0})
+        if self.flag_no_min_parents {
+            return 0;
+        }
+        self.flag_min_parents
+            .unwrap_or(if self.flag_merges { 2 } else { 0 })
     }
 
     fn max_parents(&self) -> Option<usize> {
-        if self.flag_no_max_parents { return None }
-        self.flag_max_parents.or(if self.flag_no_merges {Some(1)} else {None})
+        if self.flag_no_max_parents {
+            return None;
+        }
+        self.flag_max_parents
+            .or(if self.flag_no_merges { Some(1) } else { None })
     }
 }
 
@@ -254,8 +296,9 @@ Options:
     -h, --help              show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/ls-remote.rs
+++ b/examples/ls-remote.rs
@@ -14,13 +14,13 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use docopt::Docopt;
-use git2::{Repository, Direction};
+use git2::{Direction, Repository};
 
 #[derive(Deserialize)]
 struct Args {
@@ -30,9 +30,10 @@ struct Args {
 fn run(args: &Args) -> Result<(), git2::Error> {
     let repo = try!(Repository::open("."));
     let remote = &args.arg_remote;
-    let mut remote = try!(repo.find_remote(remote).or_else(|_| {
-        repo.remote_anonymous(remote)
-    }));
+    let mut remote = try!(
+        repo.find_remote(remote)
+            .or_else(|_| { repo.remote_anonymous(remote) })
+    );
 
     // Connect to the remote and call the printing function for each of the
     // remote references.
@@ -54,8 +55,9 @@ Options:
     -h, --help          show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/rev-parse.rs
+++ b/examples/rev-parse.rs
@@ -14,8 +14,8 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
@@ -48,7 +48,7 @@ fn run(args: &Args) -> Result<(), git2::Error> {
 
         println!("^{}", from.id());
     } else {
-        return Err(git2::Error::from_str("invalid results from revparse"))
+        return Err(git2::Error::from_str("invalid results from revparse"));
     }
     Ok(())
 }
@@ -61,8 +61,9 @@ Options:
     --git-dir           directory for the git repository to check
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -14,15 +14,15 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use std::str;
 use std::time::Duration;
 use docopt::Docopt;
-use git2::{Repository, Error, StatusOptions, ErrorCode, SubmoduleIgnore};
+use git2::{Error, ErrorCode, Repository, StatusOptions, SubmoduleIgnore};
 
 #[derive(Deserialize)]
 struct Args {
@@ -40,20 +40,28 @@ struct Args {
 }
 
 #[derive(Eq, PartialEq)]
-enum Format { Long, Short, Porcelain }
+enum Format {
+    Long,
+    Short,
+    Porcelain,
+}
 
 fn run(args: &Args) -> Result<(), Error> {
     let path = args.flag_git_dir.clone().unwrap_or_else(|| ".".to_string());
     let repo = try!(Repository::open(&path));
     if repo.is_bare() {
-        return Err(Error::from_str("cannot report status on bare repository"))
+        return Err(Error::from_str("cannot report status on bare repository"));
     }
 
     let mut opts = StatusOptions::new();
     opts.include_ignored(args.flag_ignored);
     match args.flag_untracked_files.as_ref().map(|s| &s[..]) {
-        Some("no") => { opts.include_untracked(false); }
-        Some("normal") => { opts.include_untracked(true); }
+        Some("no") => {
+            opts.include_untracked(false);
+        }
+        Some("normal") => {
+            opts.include_untracked(true);
+        }
         Some("all") => {
             opts.include_untracked(true).recurse_untracked_dirs(true);
         }
@@ -61,7 +69,9 @@ fn run(args: &Args) -> Result<(), Error> {
         None => {}
     }
     match args.flag_ignore_submodules.as_ref().map(|s| &s[..]) {
-        Some("all") => { opts.exclude_submodules(true); }
+        Some("all") => {
+            opts.exclude_submodules(true);
+        }
         Some(_) => return Err(Error::from_str("invalid ignore-submodules value")),
         None => {}
     }
@@ -93,7 +103,7 @@ fn run(args: &Args) -> Result<(), Error> {
         if args.flag_repeat {
             std::thread::sleep(Duration::new(10, 0));
         } else {
-            return Ok(())
+            return Ok(());
         }
     }
 }
@@ -101,15 +111,18 @@ fn run(args: &Args) -> Result<(), Error> {
 fn show_branch(repo: &Repository, format: &Format) -> Result<(), Error> {
     let head = match repo.head() {
         Ok(head) => Some(head),
-        Err(ref e) if e.code() == ErrorCode::UnbornBranch ||
-                      e.code() == ErrorCode::NotFound => None,
+        Err(ref e) if e.code() == ErrorCode::UnbornBranch || e.code() == ErrorCode::NotFound => {
+            None
+        }
         Err(e) => return Err(e),
     };
     let head = head.as_ref().and_then(|h| h.shorthand());
 
     if format == &Format::Long {
-        println!("# On branch {}",
-                 head.unwrap_or("Not currently on any branch"));
+        println!(
+            "# On branch {}",
+            head.unwrap_or("Not currently on any branch")
+        );
     } else {
         println!("## {}", head.unwrap_or("HEAD (no branch)"));
     }
@@ -120,8 +133,11 @@ fn print_submodules(repo: &Repository) -> Result<(), Error> {
     let modules = try!(repo.submodules());
     println!("# Submodules");
     for sm in &modules {
-        println!("# - submodule '{}' at {}", sm.name().unwrap(),
-                 sm.path().display());
+        println!(
+            "# - submodule '{}' at {}",
+            sm.name().unwrap(),
+            sm.path().display()
+        );
     }
     Ok(())
 }
@@ -135,7 +151,10 @@ fn print_long(statuses: &git2::Statuses) {
     let mut changed_in_workdir = false;
 
     // Print index changes
-    for entry in statuses.iter().filter(|e| e.status() != git2::STATUS_CURRENT) {
+    for entry in statuses
+        .iter()
+        .filter(|e| e.status() != git2::STATUS_CURRENT)
+    {
         if entry.status().contains(git2::STATUS_WT_DELETED) {
             rm_in_workdir = true;
         }
@@ -148,10 +167,12 @@ fn print_long(statuses: &git2::Statuses) {
             _ => continue,
         };
         if !header {
-            println!("\
+            println!(
+                "\
 # Changes to be committed:
 #   (use \"git reset HEAD <file>...\" to unstage)
-#");
+#"
+            );
             header = true;
         }
 
@@ -159,8 +180,7 @@ fn print_long(statuses: &git2::Statuses) {
         let new_path = entry.head_to_index().unwrap().new_file().path();
         match (old_path, new_path) {
             (Some(old), Some(new)) if old != new => {
-                println!("#\t{}  {} -> {}", istatus, old.display(),
-                         new.display());
+                println!("#\t{}  {} -> {}", istatus, old.display(), new.display());
             }
             (old, new) => {
                 println!("#\t{}  {}", istatus, old.or(new).unwrap().display());
@@ -179,9 +199,8 @@ fn print_long(statuses: &git2::Statuses) {
         // With `STATUS_OPT_INCLUDE_UNMODIFIED` (not used in this example)
         // `index_to_workdir` may not be `None` even if there are no differences,
         // in which case it will be a `Delta::Unmodified`.
-        if entry.status() == git2::STATUS_CURRENT ||
-           entry.index_to_workdir().is_none() {
-            continue
+        if entry.status() == git2::STATUS_CURRENT || entry.index_to_workdir().is_none() {
+            continue;
         }
 
         let istatus = match entry.status() {
@@ -193,12 +212,15 @@ fn print_long(statuses: &git2::Statuses) {
         };
 
         if !header {
-            println!("\
+            println!(
+                "\
 # Changes not staged for commit:
 #   (use \"git add{} <file>...\" to update what will be committed)
 #   (use \"git checkout -- <file>...\" to discard changes in working directory)
 #\
-                ", if rm_in_workdir {"/rm"} else {""});
+                ",
+                if rm_in_workdir { "/rm" } else { "" }
+            );
             header = true;
         }
 
@@ -206,8 +228,7 @@ fn print_long(statuses: &git2::Statuses) {
         let new_path = entry.index_to_workdir().unwrap().new_file().path();
         match (old_path, new_path) {
             (Some(old), Some(new)) if old != new => {
-                println!("#\t{}  {} -> {}", istatus, old.display(),
-                         new.display());
+                println!("#\t{}  {} -> {}", istatus, old.display(), new.display());
             }
             (old, new) => {
                 println!("#\t{}  {}", istatus, old.or(new).unwrap().display());
@@ -222,12 +243,17 @@ fn print_long(statuses: &git2::Statuses) {
     header = false;
 
     // Print untracked files
-    for entry in statuses.iter().filter(|e| e.status() == git2::STATUS_WT_NEW) {
+    for entry in statuses
+        .iter()
+        .filter(|e| e.status() == git2::STATUS_WT_NEW)
+    {
         if !header {
-            println!("\
+            println!(
+                "\
 # Untracked files
 #   (use \"git add <file>...\" to include in what will be committed)
-#");
+#"
+            );
             header = true;
         }
         let file = entry.index_to_workdir().unwrap().old_file().path().unwrap();
@@ -236,12 +262,17 @@ fn print_long(statuses: &git2::Statuses) {
     header = false;
 
     // Print ignored files
-    for entry in statuses.iter().filter(|e| e.status() == git2::STATUS_IGNORED) {
+    for entry in statuses
+        .iter()
+        .filter(|e| e.status() == git2::STATUS_IGNORED)
+    {
         if !header {
-            println!("\
+            println!(
+                "\
 # Ignored files
 #   (use \"git add -f <file>...\" to include in what will be committed)
-#");
+#"
+            );
             header = true;
         }
         let file = entry.index_to_workdir().unwrap().old_file().path().unwrap();
@@ -249,15 +280,20 @@ fn print_long(statuses: &git2::Statuses) {
     }
 
     if !changes_in_index && changed_in_workdir {
-        println!("no changes added to commit (use \"git add\" and/or \
-                  \"git commit -a\")");
+        println!(
+            "no changes added to commit (use \"git add\" and/or \
+             \"git commit -a\")"
+        );
     }
 }
 
 // This version of the output prefixes each path with two status columns and
 // shows submodule status information.
 fn print_short(repo: &Repository, statuses: &git2::Statuses) {
-    for entry in statuses.iter().filter(|e| e.status() != git2::STATUS_CURRENT) {
+    for entry in statuses
+        .iter()
+        .filter(|e| e.status() != git2::STATUS_CURRENT)
+    {
         let mut istatus = match entry.status() {
             s if s.contains(git2::STATUS_INDEX_NEW) => 'A',
             s if s.contains(git2::STATUS_INDEX_MODIFIED) => 'M',
@@ -268,7 +304,10 @@ fn print_short(repo: &Repository, statuses: &git2::Statuses) {
         };
         let mut wstatus = match entry.status() {
             s if s.contains(git2::STATUS_WT_NEW) => {
-                if istatus == ' ' { istatus = '?'; } '?'
+                if istatus == ' ' {
+                    istatus = '?';
+                }
+                '?'
             }
             s if s.contains(git2::STATUS_WT_MODIFIED) => 'M',
             s if s.contains(git2::STATUS_WT_DELETED) => 'D',
@@ -281,7 +320,9 @@ fn print_short(repo: &Repository, statuses: &git2::Statuses) {
             istatus = '!';
             wstatus = '!';
         }
-        if istatus == '?' && wstatus == '?' { continue }
+        if istatus == '?' && wstatus == '?' {
+            continue;
+        }
         let mut extra = "";
 
         // A commit in a tree is how submodules are stored, so let's go take a
@@ -290,14 +331,17 @@ fn print_short(repo: &Repository, statuses: &git2::Statuses) {
         // TODO: check for GIT_FILEMODE_COMMIT
         let status = entry.index_to_workdir().and_then(|diff| {
             let ignore = SubmoduleIgnore::Unspecified;
-            diff.new_file().path_bytes()
+            diff.new_file()
+                .path_bytes()
                 .and_then(|s| str::from_utf8(s).ok())
                 .and_then(|name| repo.submodule_status(name, ignore).ok())
         });
         if let Some(status) = status {
             if status.contains(git2::SUBMODULE_STATUS_WD_MODIFIED) {
                 extra = " (new commits)";
-            } else if status.contains(git2::SUBMODULE_STATUS_WD_INDEX_MODIFIED) || status.contains(git2::SUBMODULE_STATUS_WD_WD_MODIFIED) {
+            } else if status.contains(git2::SUBMODULE_STATUS_WD_INDEX_MODIFIED)
+                || status.contains(git2::SUBMODULE_STATUS_WD_WD_MODIFIED)
+            {
                 extra = " (modified content)";
             } else if status.contains(git2::SUBMODULE_STATUS_WD_UNTRACKED) {
                 extra = " (untracked content)";
@@ -316,28 +360,57 @@ fn print_short(repo: &Repository, statuses: &git2::Statuses) {
         }
 
         match (istatus, wstatus) {
-            ('R', 'R') => println!("RR {} {} {}{}", a.unwrap().display(),
-                                   b.unwrap().display(), c.unwrap().display(),
-                                   extra),
-            ('R', w) => println!("R{} {} {}{}", w, a.unwrap().display(),
-                                 b.unwrap().display(), extra),
-            (i, 'R') => println!("{}R {} {}{}", i, a.unwrap().display(),
-                                 c.unwrap().display(), extra),
+            ('R', 'R') => println!(
+                "RR {} {} {}{}",
+                a.unwrap().display(),
+                b.unwrap().display(),
+                c.unwrap().display(),
+                extra
+            ),
+            ('R', w) => println!(
+                "R{} {} {}{}",
+                w,
+                a.unwrap().display(),
+                b.unwrap().display(),
+                extra
+            ),
+            (i, 'R') => println!(
+                "{}R {} {}{}",
+                i,
+                a.unwrap().display(),
+                c.unwrap().display(),
+                extra
+            ),
             (i, w) => println!("{}{} {}{}", i, w, a.unwrap().display(), extra),
         }
     }
 
-    for entry in statuses.iter().filter(|e| e.status() == git2::STATUS_WT_NEW) {
-        println!("?? {}", entry.index_to_workdir().unwrap().old_file()
-                               .path().unwrap().display());
+    for entry in statuses
+        .iter()
+        .filter(|e| e.status() == git2::STATUS_WT_NEW)
+    {
+        println!(
+            "?? {}",
+            entry
+                .index_to_workdir()
+                .unwrap()
+                .old_file()
+                .path()
+                .unwrap()
+                .display()
+        );
     }
 }
 
 impl Args {
     fn format(&self) -> Format {
-        if self.flag_short { Format::Short }
-        else if self.flag_porcelain || self.flag_z { Format::Porcelain }
-        else { Format::Long }
+        if self.flag_short {
+            Format::Short
+        } else if self.flag_porcelain || self.flag_z {
+            Format::Porcelain
+        } else {
+            Format::Long
+        }
     }
 }
 
@@ -360,8 +433,9 @@ Options:
     -h, --help                  show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/examples/tag.rs
+++ b/examples/tag.rs
@@ -14,14 +14,14 @@
 
 #![deny(warnings)]
 
-extern crate git2;
 extern crate docopt;
+extern crate git2;
 #[macro_use]
 extern crate serde_derive;
 
 use std::str;
 use docopt::Docopt;
-use git2::{Repository, Error, Tag, Commit};
+use git2::{Commit, Error, Repository, Tag};
 
 #[derive(Deserialize)]
 struct Args {
@@ -48,14 +48,15 @@ fn run(args: &Args) -> Result<(), Error> {
         } else {
             try!(repo.tag_lightweight(name, &obj, args.flag_force));
         }
-
     } else if let Some(ref name) = args.flag_delete {
         let obj = try!(repo.revparse_single(name));
         let id = try!(obj.short_id());
         try!(repo.tag_delete(name));
-        println!("Deleted tag '{}' (was {})", name,
-                 str::from_utf8(&*id).unwrap());
-
+        println!(
+            "Deleted tag '{}' (was {})",
+            name,
+            str::from_utf8(&*id).unwrap()
+        );
     } else if args.flag_list {
         let pattern = args.arg_pattern.as_ref().map(|s| &s[..]).unwrap_or("*");
         for name in try!(repo.tag_names(Some(pattern))).iter() {
@@ -97,7 +98,10 @@ fn print_name(name: &str) {
 }
 
 fn print_list_lines(message: Option<&str>, args: &Args) {
-    let message = match message { Some(s) => s, None => return };
+    let message = match message {
+        Some(s) => s,
+        None => return,
+    };
     let mut lines = message.lines().filter(|l| !l.trim().is_empty());
     if let Some(first) = lines.next() {
         print!("{}", first);
@@ -125,8 +129,9 @@ Options:
     -h, --help              show this message
 ";
 
-    let args = Docopt::new(USAGE).and_then(|d| d.deserialize())
-                                 .unwrap_or_else(|e| e.exit());
+    let args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     match run(&args) {
         Ok(()) => {}
         Err(e) => println!("error: {}", e),

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -1,5 +1,5 @@
 use std::marker;
-use {raw, Repository, Oid, signature, Signature};
+use {raw, signature, Oid, Repository, Signature};
 use util::{self, Binding};
 use std::path::Path;
 use std::ops::Range;
@@ -29,7 +29,6 @@ pub struct BlameIter<'blame> {
 }
 
 impl<'repo> Blame<'repo> {
-
     /// Gets the number of hunks that exist in the blame structure.
     pub fn len(&self) -> usize {
         unsafe { raw::git_blame_get_hunk_count(self.raw) as usize }
@@ -67,15 +66,15 @@ impl<'repo> Blame<'repo> {
 
     /// Returns an iterator over the hunks in this blame.
     pub fn iter(&self) -> BlameIter {
-        BlameIter { range: 0..self.len(), blame: self }
+        BlameIter {
+            range: 0..self.len(),
+            blame: self,
+        }
     }
-
 }
 
 impl<'blame> BlameHunk<'blame> {
-
-    unsafe fn from_raw_const(raw: *const raw::git_blame_hunk)
-                                 -> BlameHunk<'blame> {
+    unsafe fn from_raw_const(raw: *const raw::git_blame_hunk) -> BlameHunk<'blame> {
         BlameHunk {
             raw: raw as *mut raw::git_blame_hunk,
             _marker: marker::PhantomData,
@@ -117,7 +116,7 @@ impl<'blame> BlameHunk<'blame> {
     ///
     /// Note that the start line is counting from 1.
     pub fn orig_start_line(&self) -> usize {
-        unsafe { (*self.raw).orig_start_line_number}
+        unsafe { (*self.raw).orig_start_line_number }
     }
 
     /// Returns path to the file where this hunk originated.
@@ -153,15 +152,14 @@ impl Default for BlameOptions {
 }
 
 impl BlameOptions {
-
     /// Initialize options
     pub fn new() -> BlameOptions {
         unsafe {
             let mut raw: raw::git_blame_options = mem::zeroed();
             assert_eq!(
-                raw::git_blame_init_options(&mut raw,
-                                            raw::GIT_BLAME_OPTIONS_VERSION)
-            , 0);
+                raw::git_blame_init_options(&mut raw, raw::GIT_BLAME_OPTIONS_VERSION),
+                0
+            );
 
             Binding::from_raw(&raw as *const _ as *mut _)
         }
@@ -206,26 +204,34 @@ impl BlameOptions {
 
     /// Setter for the id of the newest commit to consider.
     pub fn newest_commit(&mut self, id: Oid) -> &mut BlameOptions {
-        unsafe { self.raw.newest_commit = *id.raw(); }
+        unsafe {
+            self.raw.newest_commit = *id.raw();
+        }
         self
     }
 
     /// Setter for the id of the oldest commit to consider.
     pub fn oldest_commit(&mut self, id: Oid) -> &mut BlameOptions {
-        unsafe { self.raw.oldest_commit = *id.raw(); }
+        unsafe {
+            self.raw.oldest_commit = *id.raw();
+        }
         self
     }
-
 }
 
 impl<'repo> Binding for Blame<'repo> {
     type Raw = *mut raw::git_blame;
 
     unsafe fn from_raw(raw: *mut raw::git_blame) -> Blame<'repo> {
-        Blame { raw: raw, _marker: marker::PhantomData }
+        Blame {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
 
-    fn raw(&self) -> *mut raw::git_blame { self.raw }
+    fn raw(&self) -> *mut raw::git_blame {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Blame<'repo> {
@@ -238,10 +244,15 @@ impl<'blame> Binding for BlameHunk<'blame> {
     type Raw = *mut raw::git_blame_hunk;
 
     unsafe fn from_raw(raw: *mut raw::git_blame_hunk) -> BlameHunk<'blame> {
-        BlameHunk { raw: raw, _marker: marker::PhantomData }
+        BlameHunk {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
 
-    fn raw(&self) -> *mut raw::git_blame_hunk { self.raw }
+    fn raw(&self) -> *mut raw::git_blame_hunk {
+        self.raw
+    }
 }
 
 impl Binding for BlameOptions {
@@ -262,7 +273,9 @@ impl<'blame> Iterator for BlameIter<'blame> {
         self.range.next().and_then(|i| self.blame.get_index(i))
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 
 impl<'blame> DoubleEndedIterator for BlameIter<'blame> {
@@ -293,8 +306,8 @@ mod tests {
         let sig = repo.signature().unwrap();
         let id = repo.refname_to_id("HEAD").unwrap();
         let parent = repo.find_commit(id).unwrap();
-        let commit = repo.commit(Some("HEAD"), &sig, &sig, "commit",
-                                 &tree, &[&parent]).unwrap();
+        let commit = repo.commit(Some("HEAD"), &sig, &sig, "commit", &tree, &[&parent])
+            .unwrap();
 
         let blame = repo.blame_file(Path::new("foo/bar"), None).unwrap();
 
@@ -312,4 +325,3 @@ mod tests {
     }
 
 }
-

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -3,7 +3,7 @@ use std::mem;
 use std::slice;
 use std::io;
 
-use {raw, Oid, Object, Error};
+use {raw, Error, Object, Oid};
 use util::Binding;
 
 /// A structure to represent a git [blob][1]
@@ -36,17 +36,13 @@ impl<'repo> Blob<'repo> {
 
     /// Casts this Blob to be usable as an `Object`
     pub fn as_object(&self) -> &Object<'repo> {
-        unsafe {
-            &*(self as *const _ as *const Object<'repo>)
-        }
+        unsafe { &*(self as *const _ as *const Object<'repo>) }
     }
 
     /// Consumes Blob to be returned as an `Object`
     pub fn into_object(self) -> Object<'repo> {
         assert_eq!(mem::size_of_val(&self), mem::size_of::<Object>());
-        unsafe {
-            mem::transmute(self)
-        }
+        unsafe { mem::transmute(self) }
     }
 }
 
@@ -59,12 +55,14 @@ impl<'repo> Binding for Blob<'repo> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_blob { self.raw }
+    fn raw(&self) -> *mut raw::git_blob {
+        self.raw
+    }
 }
 
 impl<'repo> ::std::fmt::Debug for Blob<'repo> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-		f.debug_struct("Blob").field("id", &self.id()).finish()
+        f.debug_struct("Blob").field("id", &self.id()).finish()
     }
 }
 
@@ -92,7 +90,9 @@ impl<'repo> BlobWriter<'repo> {
     pub fn commit(mut self) -> Result<Oid, Error> {
         // After commit we already doesn't need cleanup on drop
         self.need_cleanup = false;
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
             try_call!(raw::git_blob_create_fromstream_commit(&mut raw, self.raw));
             Ok(Binding::from_raw(&raw as *const _))
@@ -110,7 +110,9 @@ impl<'repo> Binding for BlobWriter<'repo> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_writestream { self.raw }
+    fn raw(&self) -> *mut raw::git_writestream {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for BlobWriter<'repo> {
@@ -133,7 +135,9 @@ impl<'repo> io::Write for BlobWriter<'repo> {
             }
         }
     }
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -156,7 +160,11 @@ mod tests {
         assert!(blob.is_binary());
 
         repo.find_object(id, None).unwrap().as_blob().unwrap();
-        repo.find_object(id, None).unwrap().into_blob().ok().unwrap();
+        repo.find_object(id, None)
+            .unwrap()
+            .into_blob()
+            .ok()
+            .unwrap();
     }
 
     #[test]

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -73,7 +73,7 @@ impl<'repo> Branch<'repo> {
 
     /// Return the reference supporting the remote tracking branch, given a
     /// local branch reference.
-    pub fn upstream<'a>(&'a self) -> Result<Branch<'a>, Error> {
+    pub fn upstream(&self) -> Result<Branch, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_branch_upstream(&mut ret, &*self.get().raw()));

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -3,7 +3,7 @@ use std::marker;
 use std::ptr;
 use std::str;
 
-use {raw, Error, Reference, BranchType, References};
+use {raw, BranchType, Error, Reference, References};
 use util::Binding;
 
 /// A structure to represent a git [branch][1]
@@ -24,17 +24,25 @@ pub struct Branches<'repo> {
 
 impl<'repo> Branch<'repo> {
     /// Creates Branch type from a Reference
-    pub fn wrap(reference: Reference) -> Branch { Branch { inner: reference } }
+    pub fn wrap(reference: Reference) -> Branch {
+        Branch { inner: reference }
+    }
 
     /// Gain access to the reference that is this branch
-    pub fn get(&self) -> &Reference<'repo> { &self.inner }
+    pub fn get(&self) -> &Reference<'repo> {
+        &self.inner
+    }
 
     /// Take ownership of the underlying reference.
-    pub fn into_reference(self) -> Reference<'repo> { self.inner }
+    pub fn into_reference(self) -> Reference<'repo> {
+        self.inner
+    }
 
     /// Delete an existing branch reference.
     pub fn delete(&mut self) -> Result<(), Error> {
-        unsafe { try_call!(raw::git_branch_delete(self.get().raw())); }
+        unsafe {
+            try_call!(raw::git_branch_delete(self.get().raw()));
+        }
         Ok(())
     }
 
@@ -44,13 +52,16 @@ impl<'repo> Branch<'repo> {
     }
 
     /// Move/rename an existing local branch reference.
-    pub fn rename(&mut self, new_branch_name: &str, force: bool)
-                  -> Result<Branch<'repo>, Error> {
+    pub fn rename(&mut self, new_branch_name: &str, force: bool) -> Result<Branch<'repo>, Error> {
         let mut ret = ptr::null_mut();
         let new_branch_name = try!(CString::new(new_branch_name));
         unsafe {
-            try_call!(raw::git_branch_move(&mut ret, self.get().raw(),
-                                           new_branch_name, force));
+            try_call!(raw::git_branch_move(
+                &mut ret,
+                self.get().raw(),
+                new_branch_name,
+                force
+            ));
             Ok(Branch::wrap(Binding::from_raw(ret)))
         }
     }
@@ -85,12 +96,13 @@ impl<'repo> Branch<'repo> {
     ///
     /// If `None` is specified, then the upstream branch is unset. The name
     /// provided is the name of the branch to set as upstream.
-    pub fn set_upstream(&mut self,
-                        upstream_name: Option<&str>) -> Result<(), Error> {
+    pub fn set_upstream(&mut self, upstream_name: Option<&str>) -> Result<(), Error> {
         let upstream_name = try!(::opt_cstr(upstream_name));
         unsafe {
-            try_call!(raw::git_branch_set_upstream(self.get().raw(),
-                                                   upstream_name));
+            try_call!(raw::git_branch_set_upstream(
+                self.get().raw(),
+                upstream_name
+            ));
             Ok(())
         }
     }
@@ -101,8 +113,7 @@ impl<'repo> Branches<'repo> {
     ///
     /// This function is unsafe as it is not guaranteed that `raw` is a valid
     /// pointer.
-    pub unsafe fn from_raw(raw: *mut raw::git_branch_iterator)
-                           -> Branches<'repo> {
+    pub unsafe fn from_raw(raw: *mut raw::git_branch_iterator) -> Branches<'repo> {
         Branches {
             raw: raw,
             _marker: marker::PhantomData,

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -36,25 +36,21 @@ impl Buf {
     /// Attempt to view this buffer as a string slice.
     ///
     /// Returns `None` if the buffer is not valid utf-8.
-    pub fn as_str(&self) -> Option<&str> { str::from_utf8(&**self).ok() }
+    pub fn as_str(&self) -> Option<&str> {
+        str::from_utf8(&**self).ok()
+    }
 }
 
 impl Deref for Buf {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts(self.raw.ptr as *const u8,
-                                  self.raw.size as usize)
-        }
+        unsafe { slice::from_raw_parts(self.raw.ptr as *const u8, self.raw.size as usize) }
     }
 }
 
 impl DerefMut for Buf {
     fn deref_mut(&mut self) -> &mut [u8] {
-        unsafe {
-            slice::from_raw_parts_mut(self.raw.ptr as *mut u8,
-                                      self.raw.size as usize)
-        }
+        unsafe { slice::from_raw_parts_mut(self.raw.ptr as *mut u8, self.raw.size as usize) }
     }
 }
 
@@ -63,7 +59,9 @@ impl Binding for Buf {
     unsafe fn from_raw(raw: *mut raw::git_buf) -> Buf {
         Buf { raw: *raw }
     }
-    fn raw(&self) -> *mut raw::git_buf { &self.raw as *const _ as *mut _ }
+    fn raw(&self) -> *mut raw::git_buf {
+        &self.raw as *const _ as *mut _
+    }
 }
 
 impl Drop for Buf {

--- a/src/call.rs
+++ b/src/call.rs
@@ -33,7 +33,9 @@ pub trait Convert<T> {
     fn convert(&self) -> T;
 }
 
-pub fn convert<T, U: Convert<T>>(u: &U) -> T { u.convert() }
+pub fn convert<T, U: Convert<T>>(u: &U) -> T {
+    u.convert()
+}
 
 pub fn try(ret: libc::c_int) -> Result<libc::c_int, Error> {
     match ret {
@@ -45,9 +47,7 @@ pub fn try(ret: libc::c_int) -> Result<libc::c_int, Error> {
 pub fn last_error(code: libc::c_int) -> Error {
     // Apparently libgit2 isn't necessarily guaranteed to set the last error
     // whenever a function returns a negative value!
-    Error::last_error(code).unwrap_or_else(|| {
-        Error::from_str("an unknown error occurred")
-    })
+    Error::last_error(code).unwrap_or_else(|| Error::from_str("an unknown error occurred"))
 }
 
 mod impls {
@@ -56,29 +56,41 @@ mod impls {
 
     use libc;
 
-    use {raw, ConfigLevel, ResetType, ObjectType, BranchType, Direction};
-    use {DiffFormat, FileFavor, SubmoduleIgnore, AutotagOption, FetchPrune};
+    use {raw, BranchType, ConfigLevel, Direction, ObjectType, ResetType};
+    use {AutotagOption, DiffFormat, FetchPrune, FileFavor, SubmoduleIgnore};
     use call::Convert;
 
     impl<T: Copy> Convert<T> for T {
-        fn convert(&self) -> T { *self }
+        fn convert(&self) -> T {
+            *self
+        }
     }
 
     impl Convert<libc::c_int> for bool {
-        fn convert(&self) -> libc::c_int { *self as libc::c_int }
+        fn convert(&self) -> libc::c_int {
+            *self as libc::c_int
+        }
     }
     impl<'a, T> Convert<*const T> for &'a T {
-        fn convert(&self) -> *const T { *self as *const T }
+        fn convert(&self) -> *const T {
+            *self as *const T
+        }
     }
     impl<'a, T> Convert<*mut T> for &'a mut T {
-        fn convert(&self) -> *mut T { &**self as *const T as *mut T }
+        fn convert(&self) -> *mut T {
+            &**self as *const T as *mut T
+        }
     }
     impl<T> Convert<*const T> for *mut T {
-        fn convert(&self) -> *const T { *self as *const T }
+        fn convert(&self) -> *const T {
+            *self as *const T
+        }
     }
 
     impl Convert<*const libc::c_char> for CString {
-        fn convert(&self) -> *const libc::c_char { self.as_ptr() }
+        fn convert(&self) -> *const libc::c_char {
+            self.as_ptr()
+        }
     }
 
     impl<T, U: Convert<*const T>> Convert<*const T> for Option<U> {
@@ -89,7 +101,9 @@ mod impls {
 
     impl<T, U: Convert<*mut T>> Convert<*mut T> for Option<U> {
         fn convert(&self) -> *mut T {
-            self.as_ref().map(|s| s.convert()).unwrap_or(ptr::null_mut())
+            self.as_ref()
+                .map(|s| s.convert())
+                .unwrap_or(ptr::null_mut())
         }
     }
 
@@ -185,8 +199,7 @@ mod impls {
     impl Convert<raw::git_submodule_ignore_t> for SubmoduleIgnore {
         fn convert(&self) -> raw::git_submodule_ignore_t {
             match *self {
-                SubmoduleIgnore::Unspecified =>
-                    raw::GIT_SUBMODULE_IGNORE_UNSPECIFIED,
+                SubmoduleIgnore::Unspecified => raw::GIT_SUBMODULE_IGNORE_UNSPECIFIED,
                 SubmoduleIgnore::None => raw::GIT_SUBMODULE_IGNORE_NONE,
                 SubmoduleIgnore::Untracked => raw::GIT_SUBMODULE_IGNORE_UNTRACKED,
                 SubmoduleIgnore::Dirty => raw::GIT_SUBMODULE_IGNORE_DIRTY,
@@ -198,8 +211,7 @@ mod impls {
     impl Convert<raw::git_remote_autotag_option_t> for AutotagOption {
         fn convert(&self) -> raw::git_remote_autotag_option_t {
             match *self {
-                AutotagOption::Unspecified =>
-                    raw::GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED,
+                AutotagOption::Unspecified => raw::GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED,
                 AutotagOption::None => raw::GIT_REMOTE_DOWNLOAD_TAGS_NONE,
                 AutotagOption::Auto => raw::GIT_REMOTE_DOWNLOAD_TAGS_AUTO,
                 AutotagOption::All => raw::GIT_REMOTE_DOWNLOAD_TAGS_ALL,

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -81,17 +81,19 @@ impl<'a> CertHostkey<'a> {
 impl<'a> CertX509<'a> {
     /// Return the X.509 certificate data as a byte slice
     pub fn data(&self) -> &[u8] {
-        unsafe {
-            slice::from_raw_parts((*self.raw).data as *const u8,
-                                  (*self.raw).len as usize)
-        }
+        unsafe { slice::from_raw_parts((*self.raw).data as *const u8, (*self.raw).len as usize) }
     }
 }
 
 impl<'a> Binding for Cert<'a> {
     type Raw = *mut raw::git_cert;
     unsafe fn from_raw(raw: *mut raw::git_cert) -> Cert<'a> {
-        Cert { raw: raw, _marker: marker::PhantomData }
+        Cert {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_cert { self.raw }
+    fn raw(&self) -> *mut raw::git_cert {
+        self.raw
+    }
 }

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -5,7 +5,7 @@ use std::ptr;
 use std::str;
 use libc;
 
-use {raw, signature, Oid, Error, Signature, Tree, Time, Object};
+use {raw, signature, Error, Object, Oid, Signature, Time, Tree};
 use util::Binding;
 
 /// A structure to represent a git [commit][1]
@@ -51,7 +51,9 @@ impl<'repo> Commit<'repo> {
     }
 
     /// Get access to the underlying raw pointer.
-    pub fn raw(&self) -> *mut raw::git_commit { self.raw }
+    pub fn raw(&self) -> *mut raw::git_commit {
+        self.raw
+    }
 
     /// Get the full message of a commit.
     ///
@@ -68,9 +70,7 @@ impl<'repo> Commit<'repo> {
     /// The returned message will be slightly prettified by removing any
     /// potential leading newlines.
     pub fn message_bytes(&self) -> &[u8] {
-        unsafe {
-            ::opt_bytes(self, raw::git_commit_message(&*self.raw)).unwrap()
-        }
+        unsafe { ::opt_bytes(self, raw::git_commit_message(&*self.raw)).unwrap() }
     }
 
     /// Get the encoding for the message of a commit, as a string representing a
@@ -78,9 +78,7 @@ impl<'repo> Commit<'repo> {
     ///
     /// `None` will be returned if the encoding is not known
     pub fn message_encoding(&self) -> Option<&str> {
-        let bytes = unsafe {
-            ::opt_bytes(self, raw::git_commit_message(&*self.raw))
-        };
+        let bytes = unsafe { ::opt_bytes(self, raw::git_commit_message(&*self.raw)) };
         bytes.map(|b| str::from_utf8(b).unwrap())
     }
 
@@ -93,9 +91,7 @@ impl<'repo> Commit<'repo> {
 
     /// Get the full raw message of a commit.
     pub fn message_raw_bytes(&self) -> &[u8] {
-        unsafe {
-            ::opt_bytes(self, raw::git_commit_message_raw(&*self.raw)).unwrap()
-        }
+        unsafe { ::opt_bytes(self, raw::git_commit_message_raw(&*self.raw)).unwrap() }
     }
 
     /// Get the full raw text of the commit header.
@@ -107,9 +103,7 @@ impl<'repo> Commit<'repo> {
 
     /// Get the full raw text of the commit header.
     pub fn raw_header_bytes(&self) -> &[u8] {
-        unsafe {
-            ::opt_bytes(self, raw::git_commit_raw_header(&*self.raw)).unwrap()
-        }
+        unsafe { ::opt_bytes(self, raw::git_commit_raw_header(&*self.raw)).unwrap() }
     }
 
     /// Get the short "summary" of the git commit message.
@@ -140,21 +134,29 @@ impl<'repo> Commit<'repo> {
     /// committer's preferred time zone.
     pub fn time(&self) -> Time {
         unsafe {
-            Time::new(raw::git_commit_time(&*self.raw) as i64,
-                      raw::git_commit_time_offset(&*self.raw) as i32)
+            Time::new(
+                raw::git_commit_time(&*self.raw) as i64,
+                raw::git_commit_time_offset(&*self.raw) as i32,
+            )
         }
     }
 
     /// Creates a new iterator over the parents of this commit.
     pub fn parents<'a>(&'a self) -> Parents<'a, 'repo> {
         let max = unsafe { raw::git_commit_parentcount(&*self.raw) as usize };
-        Parents { range: 0..max, commit: self }
+        Parents {
+            range: 0..max,
+            commit: self,
+        }
     }
 
     /// Creates a new iterator over the parents of this commit.
     pub fn parent_ids(&self) -> ParentIds {
         let max = unsafe { raw::git_commit_parentcount(&*self.raw) as usize };
-        ParentIds { range: 0..max, commit: self }
+        ParentIds {
+            range: 0..max,
+            commit: self,
+        }
     }
 
     /// Get the author of this commit.
@@ -182,26 +184,32 @@ impl<'repo> Commit<'repo> {
     /// For information about `update_ref`, see [`Repository::commit`].
     ///
     /// [`Repository::commit`]: struct.Repository.html#method.commit
-    pub fn amend(&self,
-                 update_ref: Option<&str>,
-                 author: Option<&Signature>,
-                 committer: Option<&Signature>,
-                 message_encoding: Option<&str>,
-                 message: Option<&str>,
-                 tree: Option<&Tree<'repo>>) -> Result<Oid, Error> {
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+    pub fn amend(
+        &self,
+        update_ref: Option<&str>,
+        author: Option<&Signature>,
+        committer: Option<&Signature>,
+        message_encoding: Option<&str>,
+        message: Option<&str>,
+        tree: Option<&Tree<'repo>>,
+    ) -> Result<Oid, Error> {
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         let update_ref = try!(::opt_cstr(update_ref));
         let encoding = try!(::opt_cstr(message_encoding));
         let message = try!(::opt_cstr(message));
         unsafe {
-            try_call!(raw::git_commit_amend(&mut raw,
-                                            self.raw(),
-                                            update_ref,
-                                            author.map(|s| s.raw()),
-                                            committer.map(|s| s.raw()),
-                                            encoding,
-                                            message,
-                                            tree.map(|t| t.raw())));
+            try_call!(raw::git_commit_amend(
+                &mut raw,
+                self.raw(),
+                update_ref,
+                author.map(|s| s.raw()),
+                committer.map(|s| s.raw()),
+                encoding,
+                message,
+                tree.map(|t| t.raw())
+            ));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -212,8 +220,11 @@ impl<'repo> Commit<'repo> {
     pub fn parent(&self, i: usize) -> Result<Commit<'repo>, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
-            try_call!(raw::git_commit_parent(&mut raw, &*self.raw,
-                                             i as libc::c_uint));
+            try_call!(raw::git_commit_parent(
+                &mut raw,
+                &*self.raw,
+                i as libc::c_uint
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -237,17 +248,13 @@ impl<'repo> Commit<'repo> {
 
     /// Casts this Commit to be usable as an `Object`
     pub fn as_object(&self) -> &Object<'repo> {
-        unsafe {
-            &*(self as *const _ as *const Object<'repo>)
-        }
+        unsafe { &*(self as *const _ as *const Object<'repo>) }
     }
 
     /// Consumes Commit to be returned as an `Object`
     pub fn into_object(self) -> Object<'repo> {
         assert_eq!(mem::size_of_val(&self), mem::size_of::<Object>());
-        unsafe {
-            mem::transmute(self)
-        }
+        unsafe { mem::transmute(self) }
     }
 }
 
@@ -259,17 +266,19 @@ impl<'repo> Binding for Commit<'repo> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_commit { self.raw }
+    fn raw(&self) -> *mut raw::git_commit {
+        self.raw
+    }
 }
 
 impl<'repo> ::std::fmt::Debug for Commit<'repo> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-		let mut ds = f.debug_struct("Commit");
-		ds.field("id", &self.id());
-		if let Some(summary) = self.summary() {
-			ds.field("summary", &summary);
-		}
-		ds.finish()
+        let mut ds = f.debug_struct("Commit");
+        ds.field("id", &self.id());
+        if let Some(summary) = self.summary() {
+            ds.field("summary", &summary);
+        }
+        ds.finish()
     }
 }
 
@@ -278,12 +287,16 @@ impl<'repo, 'commit> Iterator for Parents<'commit, 'repo> {
     fn next(&mut self) -> Option<Commit<'repo>> {
         self.range.next().map(|i| self.commit.parent(i).unwrap())
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 
 impl<'repo, 'commit> DoubleEndedIterator for Parents<'commit, 'repo> {
     fn next_back(&mut self) -> Option<Commit<'repo>> {
-        self.range.next_back().map(|i| self.commit.parent(i).unwrap())
+        self.range
+            .next_back()
+            .map(|i| self.commit.parent(i).unwrap())
     }
 }
 
@@ -294,12 +307,16 @@ impl<'commit> Iterator for ParentIds<'commit> {
     fn next(&mut self) -> Option<Oid> {
         self.range.next().map(|i| self.commit.parent_id(i).unwrap())
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 
 impl<'commit> DoubleEndedIterator for ParentIds<'commit> {
     fn next_back(&mut self) -> Option<Oid> {
-        self.range.next_back().map(|i| self.commit.parent_id(i).unwrap())
+        self.range
+            .next_back()
+            .map(|i| self.commit.parent_id(i).unwrap())
     }
 }
 
@@ -342,18 +359,21 @@ mod tests {
 
         let sig = repo.signature().unwrap();
         let tree = repo.find_tree(commit.tree_id()).unwrap();
-        let id = repo.commit(Some("HEAD"), &sig, &sig, "bar", &tree,
-                             &[&commit]).unwrap();
+        let id = repo.commit(Some("HEAD"), &sig, &sig, "bar", &tree, &[&commit])
+            .unwrap();
         let head = repo.find_commit(id).unwrap();
 
-        let new_head = head.amend(Some("HEAD"), None, None, None,
-                                  Some("new message"), None).unwrap();
+        let new_head = head.amend(Some("HEAD"), None, None, None, Some("new message"), None)
+            .unwrap();
         let new_head = repo.find_commit(new_head).unwrap();
         assert_eq!(new_head.message(), Some("new message"));
         new_head.into_object();
 
         repo.find_object(target, None).unwrap().as_commit().unwrap();
-        repo.find_object(target, None).unwrap().into_commit().ok().unwrap();
+        repo.find_object(target, None)
+            .unwrap()
+            .into_commit()
+            .ok()
+            .unwrap();
     }
 }
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::ptr;
 use std::str;
 use libc;
 
-use {raw, Error, ConfigLevel, Buf, IntoCString};
+use {raw, Buf, ConfigLevel, Error, IntoCString};
 use util::{self, Binding};
 
 /// A structure representing a git configuration key/value store
@@ -81,7 +81,9 @@ impl Config {
     pub fn find_global() -> Result<PathBuf, Error> {
         ::init();
         let buf = Buf::new();
-        unsafe { try_call!(raw::git_config_find_global(buf.raw())); }
+        unsafe {
+            try_call!(raw::git_config_find_global(buf.raw()));
+        }
         Ok(util::bytes2path(&buf).to_path_buf())
     }
 
@@ -91,7 +93,9 @@ impl Config {
     pub fn find_system() -> Result<PathBuf, Error> {
         ::init();
         let buf = Buf::new();
-        unsafe { try_call!(raw::git_config_find_system(buf.raw())); }
+        unsafe {
+            try_call!(raw::git_config_find_system(buf.raw()));
+        }
         Ok(util::bytes2path(&buf).to_path_buf())
     }
 
@@ -102,7 +106,9 @@ impl Config {
     pub fn find_xdg() -> Result<PathBuf, Error> {
         ::init();
         let buf = Buf::new();
-        unsafe { try_call!(raw::git_config_find_xdg(buf.raw())); }
+        unsafe {
+            try_call!(raw::git_config_find_xdg(buf.raw()));
+        }
         Ok(util::bytes2path(&buf).to_path_buf())
     }
 
@@ -115,12 +121,15 @@ impl Config {
     /// Further queries on this config object will access each of the config
     /// file instances in order (instances with a higher priority level will be
     /// accessed first).
-    pub fn add_file(&mut self, path: &Path, level: ConfigLevel,
-                    force: bool) -> Result<(), Error> {
+    pub fn add_file(&mut self, path: &Path, level: ConfigLevel, force: bool) -> Result<(), Error> {
         let path = try!(path.into_c_string());
         unsafe {
-            try_call!(raw::git_config_add_file_ondisk(self.raw, path, level,
-                                                      force));
+            try_call!(raw::git_config_add_file_ondisk(
+                self.raw,
+                path,
+                level,
+                force
+            ));
             Ok(())
         }
     }
@@ -145,7 +154,6 @@ impl Config {
         let name = try!(CString::new(name));
         unsafe {
             try_call!(raw::git_config_get_bool(&mut out, &*self.raw, name));
-
         }
         Ok(!(out == 0))
     }
@@ -160,7 +168,6 @@ impl Config {
         let name = try!(CString::new(name));
         unsafe {
             try_call!(raw::git_config_get_int32(&mut out, &*self.raw, name));
-
         }
         Ok(out)
     }
@@ -184,9 +191,8 @@ impl Config {
     /// This is the same as `get_bytes` except that it may return `Err` if
     /// the bytes are not valid utf-8.
     pub fn get_str(&self, name: &str) -> Result<&str, Error> {
-        str::from_utf8(try!(self.get_bytes(name))).map_err(|_| {
-            Error::from_str("configuration value is not valid utf8")
-        })
+        str::from_utf8(try!(self.get_bytes(name)))
+            .map_err(|_| Error::from_str("configuration value is not valid utf8"))
     }
 
     /// Get the value of a string config variable as a byte slice.
@@ -210,9 +216,9 @@ impl Config {
         unsafe {
             try_call!(raw::git_config_get_string_buf(ret.raw(), self.raw, name));
         }
-        str::from_utf8(&ret).map(|s| s.to_string()).map_err(|_| {
-            Error::from_str("configuration value is not valid utf8")
-        })
+        str::from_utf8(&ret)
+            .map(|s| s.to_string())
+            .map_err(|_| Error::from_str("configuration value is not valid utf8"))
     }
 
     /// Get the value of a path config variable as an owned .
@@ -259,9 +265,7 @@ impl Config {
             match glob {
                 Some(s) => {
                     let s = try!(CString::new(s));
-                    try_call!(raw::git_config_iterator_glob_new(&mut ret,
-                                                                &*self.raw,
-                                                                s));
+                    try_call!(raw::git_config_iterator_glob_new(&mut ret, &*self.raw, s));
                 }
                 None => {
                     try_call!(raw::git_config_iterator_new(&mut ret, &*self.raw));
@@ -406,7 +410,9 @@ impl Binding for Config {
     unsafe fn from_raw(raw: *mut raw::git_config) -> Config {
         Config { raw: raw }
     }
-    fn raw(&self) -> *mut raw::git_config { self.raw }
+    fn raw(&self) -> *mut raw::git_config {
+        self.raw
+    }
 }
 
 impl Drop for Config {
@@ -419,7 +425,9 @@ impl<'cfg> ConfigEntry<'cfg> {
     /// Gets the name of this entry.
     ///
     /// May return `None` if the name is not valid utf-8
-    pub fn name(&self) -> Option<&str> { str::from_utf8(self.name_bytes()).ok() }
+    pub fn name(&self) -> Option<&str> {
+        str::from_utf8(self.name_bytes()).ok()
+    }
 
     /// Gets the name of this entry as a byte slice.
     pub fn name_bytes(&self) -> &[u8] {
@@ -429,7 +437,9 @@ impl<'cfg> ConfigEntry<'cfg> {
     /// Gets the value of this entry.
     ///
     /// May return `None` if the value is not valid utf-8
-    pub fn value(&self) -> Option<&str> { str::from_utf8(self.value_bytes()).ok() }
+    pub fn value(&self) -> Option<&str> {
+        str::from_utf8(self.value_bytes()).ok()
+    }
 
     /// Gets the value of this entry as a byte slice.
     pub fn value_bytes(&self) -> &[u8] {
@@ -445,28 +455,30 @@ impl<'cfg> ConfigEntry<'cfg> {
 impl<'cfg> Binding for ConfigEntry<'cfg> {
     type Raw = *mut raw::git_config_entry;
 
-    unsafe fn from_raw(raw: *mut raw::git_config_entry)
-                           -> ConfigEntry<'cfg> {
+    unsafe fn from_raw(raw: *mut raw::git_config_entry) -> ConfigEntry<'cfg> {
         ConfigEntry {
             raw: raw,
             _marker: marker::PhantomData,
             owned: true,
         }
     }
-    fn raw(&self) -> *mut raw::git_config_entry { self.raw }
+    fn raw(&self) -> *mut raw::git_config_entry {
+        self.raw
+    }
 }
 
 impl<'cfg> Binding for ConfigEntries<'cfg> {
     type Raw = *mut raw::git_config_iterator;
 
-    unsafe fn from_raw(raw: *mut raw::git_config_iterator)
-                           -> ConfigEntries<'cfg> {
+    unsafe fn from_raw(raw: *mut raw::git_config_iterator) -> ConfigEntries<'cfg> {
         ConfigEntries {
             raw: raw,
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_config_iterator { self.raw }
+    fn raw(&self) -> *mut raw::git_config_iterator {
+        self.raw
+    }
 }
 
 // entries are only valid until the iterator is freed, so this impl is for
@@ -592,7 +604,7 @@ mod tests {
         assert_eq!(Config::parse_i32("1k").unwrap(), 1024);
         assert_eq!(Config::parse_i32("4k").unwrap(), 4096);
         assert_eq!(Config::parse_i32("1M").unwrap(), 1048576);
-        assert_eq!(Config::parse_i32("1G").unwrap(), 1024*1024*1024);
+        assert_eq!(Config::parse_i32("1G").unwrap(), 1024 * 1024 * 1024);
 
         assert_eq!(Config::parse_i64("0").unwrap(), 0);
         assert_eq!(Config::parse_i64("1").unwrap(), 1);
@@ -602,7 +614,7 @@ mod tests {
         assert_eq!(Config::parse_i64("1k").unwrap(), 1024);
         assert_eq!(Config::parse_i64("4k").unwrap(), 4096);
         assert_eq!(Config::parse_i64("1M").unwrap(), 1048576);
-        assert_eq!(Config::parse_i64("1G").unwrap(), 1024*1024*1024);
-        assert_eq!(Config::parse_i64("100G").unwrap(), 100*1024*1024*1024);
+        assert_eq!(Config::parse_i64("1G").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(Config::parse_i64("100G").unwrap(), 100 * 1024 * 1024 * 1024);
     }
 }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -3,9 +3,9 @@ use std::mem;
 use std::ffi::CString;
 use std::ptr;
 
-use libc::{c_uint, c_int};
+use libc::{c_int, c_uint};
 
-use {raw, Repository, Error, Buf};
+use {raw, Buf, Error, Repository};
 use util::Binding;
 
 /// The result of a `describe` operation on either an `Describe` or a
@@ -29,8 +29,7 @@ pub struct DescribeFormatOptions {
 
 impl<'repo> Describe<'repo> {
     /// Prints this describe result, returning the result as a string.
-    pub fn format(&self, opts: Option<&DescribeFormatOptions>)
-                  -> Result<String, Error> {
+    pub fn format(&self, opts: Option<&DescribeFormatOptions>) -> Result<String, Error> {
         let buf = Buf::new();
         let opts = opts.map(|o| &o.raw as *const _).unwrap_or(ptr::null());
         unsafe {
@@ -44,9 +43,14 @@ impl<'repo> Binding for Describe<'repo> {
     type Raw = *mut raw::git_describe_result;
 
     unsafe fn from_raw(raw: *mut raw::git_describe_result) -> Describe<'repo> {
-        Describe { raw: raw, _marker: marker::PhantomData, }
+        Describe {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_describe_result { self.raw }
+    fn raw(&self) -> *mut raw::git_describe_result {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Describe<'repo> {
@@ -164,8 +168,7 @@ impl DescribeOptions {
 impl Binding for DescribeOptions {
     type Raw = *mut raw::git_describe_options;
 
-    unsafe fn from_raw(_raw: *mut raw::git_describe_options)
-                       -> DescribeOptions {
+    unsafe fn from_raw(_raw: *mut raw::git_describe_options) -> DescribeOptions {
         panic!("unimplemened")
     }
     fn raw(&self) -> *mut raw::git_describe_options {
@@ -182,8 +185,7 @@ mod tests {
         let (_td, repo) = ::test::repo_init();
         let head = t!(repo.head()).target().unwrap();
 
-        let d = t!(repo.describe(DescribeOptions::new()
-                                        .show_commit_oid_as_fallback(true)));
+        let d = t!(repo.describe(DescribeOptions::new().show_commit_oid_as_fallback(true)));
         let id = head.to_string();
         assert_eq!(t!(d.format(None)), &id[..7]);
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -997,7 +997,7 @@ impl DiffFindOptions {
     /// `diff.renames` should be used instead. This is overridden once any flag
     /// is set.
     pub fn by_config(&mut self) -> &mut DiffFindOptions {
-        self.flag(0xffffffff, false)
+        self.flag(0xffff_ffff, false)
     }
 
     /// Look for renames?

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,9 +5,9 @@ use std::ops::Range;
 use std::path::Path;
 use std::ptr;
 use std::slice;
-use libc::{c_char, size_t, c_void, c_int};
+use libc::{c_char, c_int, c_void, size_t};
 
-use {raw, panic, Buf, Delta, Oid, Repository, Error, DiffFormat};
+use {panic, raw, Buf, Delta, DiffFormat, Error, Oid, Repository};
 use {DiffStatsFormat, IntoCString};
 use util::{self, Binding};
 
@@ -126,14 +126,19 @@ impl<'repo> Diff<'repo> {
     /// is from the "from" list (with the exception that if the item has a
     /// pending DELETE in the middle, then it will show as deleted).
     pub fn merge(&mut self, from: &Diff<'repo>) -> Result<(), Error> {
-        unsafe { try_call!(raw::git_diff_merge(self.raw, &*from.raw)); }
+        unsafe {
+            try_call!(raw::git_diff_merge(self.raw, &*from.raw));
+        }
         Ok(())
     }
 
     /// Returns an iterator over the deltas in this diff.
     pub fn deltas(&self) -> Deltas {
         let num_deltas = unsafe { raw::git_diff_num_deltas(&*self.raw) };
-        Deltas { range: 0..(num_deltas as usize), diff: self }
+        Deltas {
+            range: 0..(num_deltas as usize),
+            diff: self,
+        }
     }
 
     /// Return the diff delta for an entry in the diff list.
@@ -154,14 +159,18 @@ impl<'repo> Diff<'repo> {
     /// Returning `false` from the callback will terminate the iteration and
     /// return an error from this function.
     pub fn print<F>(&self, format: DiffFormat, mut cb: F) -> Result<(), Error>
-                    where F: FnMut(DiffDelta,
-                                   Option<DiffHunk>,
-                                   DiffLine) -> bool {
+    where
+        F: FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool,
+    {
         let mut cb: &mut PrintCb = &mut cb;
         let ptr = &mut cb as *mut _;
         unsafe {
-            try_call!(raw::git_diff_print(self.raw, format, print_cb,
-                                          ptr as *mut _));
+            try_call!(raw::git_diff_print(
+                self.raw,
+                format,
+                print_cb,
+                ptr as *mut _
+            ));
             Ok(())
         }
     }
@@ -170,11 +179,13 @@ impl<'repo> Diff<'repo> {
     ///
     /// Returning `false` from any callback will terminate the iteration and
     /// return an error from this function.
-    pub fn foreach(&self,
-                   file_cb: &mut FileCb,
-                   binary_cb: Option<&mut BinaryCb>,
-                   hunk_cb: Option<&mut HunkCb>,
-                   line_cb: Option<&mut LineCb>) -> Result<(), Error> {
+    pub fn foreach(
+        &self,
+        file_cb: &mut FileCb,
+        binary_cb: Option<&mut BinaryCb>,
+        hunk_cb: Option<&mut HunkCb>,
+        line_cb: Option<&mut LineCb>,
+    ) -> Result<(), Error> {
         let mut cbs = ForeachCallbacks {
             file: file_cb,
             binary: binary_cb,
@@ -198,9 +209,14 @@ impl<'repo> Diff<'repo> {
             } else {
                 None
             };
-            try_call!(raw::git_diff_foreach(self.raw, file_cb_c, binary_cb_c,
-                                            hunk_cb_c, line_cb_c,
-                                            ptr as *mut _));
+            try_call!(raw::git_diff_foreach(
+                self.raw,
+                file_cb_c,
+                binary_cb_c,
+                hunk_cb_c,
+                line_cb_c,
+                ptr as *mut _
+            ));
             Ok(())
         }
     }
@@ -220,20 +236,23 @@ impl<'repo> Diff<'repo> {
     /// renames or copies with new entries reflecting those changes. This also
     /// will, if requested, break modified files into add/remove pairs if the
     /// amount of change is above a threshold.
-    pub fn find_similar(&mut self, opts: Option<&mut DiffFindOptions>)
-                        -> Result<(), Error> {
+    pub fn find_similar(&mut self, opts: Option<&mut DiffFindOptions>) -> Result<(), Error> {
         let opts = opts.map(|opts| &opts.raw);
-        unsafe { try_call!(raw::git_diff_find_similar(self.raw, opts)); }
+        unsafe {
+            try_call!(raw::git_diff_find_similar(self.raw, opts));
+        }
         Ok(())
     }
 
     // TODO: num_deltas_of_type, format_email, find_similar
 }
 
-pub extern fn print_cb(delta: *const raw::git_diff_delta,
-                   hunk: *const raw::git_diff_hunk,
-                   line: *const raw::git_diff_line,
-                   data: *mut c_void) -> c_int {
+pub extern "C" fn print_cb(
+    delta: *const raw::git_diff_delta,
+    hunk: *const raw::git_diff_hunk,
+    line: *const raw::git_diff_line,
+    data: *mut c_void,
+) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let hunk = Binding::from_raw_opt(hunk);
@@ -243,13 +262,19 @@ pub extern fn print_cb(delta: *const raw::git_diff_delta,
             let data = data as *mut &mut PrintCb;
             (*data)(delta, hunk, line)
         });
-        if r == Some(true) {0} else {-1}
+        if r == Some(true) {
+            0
+        } else {
+            -1
+        }
     }
 }
 
-extern fn file_cb_c(delta: *const raw::git_diff_delta,
-                    progress: f32,
-                    data: *mut c_void) -> c_int {
+extern "C" fn file_cb_c(
+    delta: *const raw::git_diff_delta,
+    progress: f32,
+    data: *mut c_void,
+) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
 
@@ -257,13 +282,19 @@ extern fn file_cb_c(delta: *const raw::git_diff_delta,
             let cbs = data as *mut ForeachCallbacks;
             ((*cbs).file)(delta, progress)
         });
-        if r == Some(true) {0} else {-1}
+        if r == Some(true) {
+            0
+        } else {
+            -1
+        }
     }
 }
 
-extern fn binary_cb_c(delta: *const raw::git_diff_delta,
-                      binary: *const raw::git_diff_binary,
-                      data: *mut c_void) -> c_int {
+extern "C" fn binary_cb_c(
+    delta: *const raw::git_diff_delta,
+    binary: *const raw::git_diff_binary,
+    data: *mut c_void,
+) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let binary = Binding::from_raw(binary);
@@ -275,13 +306,19 @@ extern fn binary_cb_c(delta: *const raw::git_diff_delta,
                 None => false,
             }
         });
-        if r == Some(true) {0} else {-1}
+        if r == Some(true) {
+            0
+        } else {
+            -1
+        }
     }
 }
 
-extern fn hunk_cb_c(delta: *const raw::git_diff_delta,
-                    hunk: *const raw::git_diff_hunk,
-                    data: *mut c_void) -> c_int {
+extern "C" fn hunk_cb_c(
+    delta: *const raw::git_diff_delta,
+    hunk: *const raw::git_diff_hunk,
+    data: *mut c_void,
+) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let hunk = Binding::from_raw(hunk);
@@ -293,14 +330,20 @@ extern fn hunk_cb_c(delta: *const raw::git_diff_delta,
                 None => false,
             }
         });
-        if r == Some(true) {0} else {-1}
+        if r == Some(true) {
+            0
+        } else {
+            -1
+        }
     }
 }
 
-extern fn line_cb_c(delta: *const raw::git_diff_delta,
-                    hunk: *const raw::git_diff_hunk,
-                    line: *const raw::git_diff_line,
-                    data: *mut c_void) -> c_int {
+extern "C" fn line_cb_c(
+    delta: *const raw::git_diff_delta,
+    hunk: *const raw::git_diff_hunk,
+    line: *const raw::git_diff_line,
+    data: *mut c_void,
+) -> c_int {
     unsafe {
         let delta = Binding::from_raw(delta as *mut _);
         let hunk = Binding::from_raw_opt(hunk);
@@ -313,7 +356,11 @@ extern fn line_cb_c(delta: *const raw::git_diff_delta,
                 None => false,
             }
         });
-        if r == Some(true) {0} else {-1}
+        if r == Some(true) {
+            0
+        } else {
+            -1
+        }
     }
 }
 
@@ -322,11 +369,13 @@ impl<'repo> Binding for Diff<'repo> {
     type Raw = *mut raw::git_diff;
     unsafe fn from_raw(raw: *mut raw::git_diff) -> Diff<'repo> {
         Diff {
-          raw: raw,
-          _marker: marker::PhantomData,
+            raw: raw,
+            _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_diff { self.raw }
+    fn raw(&self) -> *mut raw::git_diff {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Diff<'repo> {
@@ -391,7 +440,9 @@ impl<'a> Binding for DiffDelta<'a> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_diff_delta { self.raw }
+    fn raw(&self) -> *mut raw::git_diff_delta {
+        self.raw
+    }
 }
 
 impl<'a> DiffFile<'a> {
@@ -417,7 +468,9 @@ impl<'a> DiffFile<'a> {
     }
 
     /// Returns the size of this entry, in bytes
-    pub fn size(&self) -> u64 { unsafe { (*self.raw).size as u64 } }
+    pub fn size(&self) -> u64 {
+        unsafe { (*self.raw).size as u64 }
+    }
 
     // TODO: expose flags/mode
 }
@@ -430,7 +483,9 @@ impl<'a> Binding for DiffFile<'a> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *const raw::git_diff_file { self.raw }
+    fn raw(&self) -> *const raw::git_diff_file {
+        self.raw
+    }
 }
 
 impl Default for DiffOptions {
@@ -452,9 +507,7 @@ impl DiffOptions {
             old_prefix: None,
             new_prefix: None,
         };
-        assert_eq!(unsafe {
-            raw::git_diff_init_options(&mut opts.raw, 1)
-        }, 0);
+        assert_eq!(unsafe { raw::git_diff_init_options(&mut opts.raw, 1) }, 0);
         opts
     }
 
@@ -548,8 +601,7 @@ impl DiffOptions {
     ///
     /// This flag turns off that scan and immediately labels an untracked
     /// directory as untracked (changing the behavior to not match core git).
-    pub fn enable_fast_untracked_dirs(&mut self, enable: bool)
-                                      -> &mut DiffOptions {
+    pub fn enable_fast_untracked_dirs(&mut self, enable: bool) -> &mut DiffOptions {
         self.flag(raw::GIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS, enable)
     }
 
@@ -567,8 +619,7 @@ impl DiffOptions {
     }
 
     /// Include unreadable files in the diff
-    pub fn include_unreadable_as_untracked(&mut self, include: bool)
-                                           -> &mut DiffOptions {
+    pub fn include_unreadable_as_untracked(&mut self, include: bool) -> &mut DiffOptions {
         self.flag(raw::GIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED, include)
     }
 
@@ -682,8 +733,7 @@ impl DiffOptions {
     }
 
     /// Add to the array of paths/fnmatch patterns to constrain the diff.
-    pub fn pathspec<T: IntoCString>(&mut self, pathspec: T)
-                                       -> &mut DiffOptions {
+    pub fn pathspec<T: IntoCString>(&mut self, pathspec: T) -> &mut DiffOptions {
         let s = pathspec.into_c_string().unwrap();
         self.pathspec_ptrs.push(s.as_ptr());
         self.pathspec.push(s);
@@ -695,10 +745,14 @@ impl DiffOptions {
     /// This function is unsafe as the pointer is only valid so long as this
     /// structure is not moved, modified, or used elsewhere.
     pub unsafe fn raw(&mut self) -> *const raw::git_diff_options {
-        self.raw.old_prefix = self.old_prefix.as_ref().map(|s| s.as_ptr())
-                                  .unwrap_or(ptr::null());
-        self.raw.new_prefix = self.new_prefix.as_ref().map(|s| s.as_ptr())
-                                  .unwrap_or(ptr::null());
+        self.raw.old_prefix = self.old_prefix
+            .as_ref()
+            .map(|s| s.as_ptr())
+            .unwrap_or(ptr::null());
+        self.raw.new_prefix = self.new_prefix
+            .as_ref()
+            .map(|s| s.as_ptr())
+            .unwrap_or(ptr::null());
         self.raw.pathspec.count = self.pathspec_ptrs.len() as size_t;
         self.raw.pathspec.strings = self.pathspec_ptrs.as_ptr() as *mut _;
         &self.raw as *const _
@@ -712,7 +766,9 @@ impl<'diff> Iterator for Deltas<'diff> {
     fn next(&mut self) -> Option<DiffDelta<'diff>> {
         self.range.next().and_then(|i| self.diff.get_delta(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'diff> DoubleEndedIterator for Deltas<'diff> {
     fn next_back(&mut self) -> Option<DiffDelta<'diff>> {
@@ -751,8 +807,10 @@ impl<'a> DiffLine<'a> {
     /// Content of this line as bytes.
     pub fn content(&self) -> &[u8] {
         unsafe {
-            slice::from_raw_parts((*self.raw).content as *const u8,
-                                  (*self.raw).content_len as usize)
+            slice::from_raw_parts(
+                (*self.raw).content as *const u8,
+                (*self.raw).content_len as usize,
+            )
         }
     }
 
@@ -791,7 +849,9 @@ impl<'a> Binding for DiffLine<'a> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *const raw::git_diff_line { self.raw }
+    fn raw(&self) -> *const raw::git_diff_line {
+        self.raw
+    }
 }
 
 impl<'a> DiffHunk<'a> {
@@ -818,8 +878,10 @@ impl<'a> DiffHunk<'a> {
     /// Header text
     pub fn header(&self) -> &[u8] {
         unsafe {
-            slice::from_raw_parts((*self.raw).header.as_ptr() as *const u8,
-                                  (*self.raw).header_len as usize)
+            slice::from_raw_parts(
+                (*self.raw).header.as_ptr() as *const u8,
+                (*self.raw).header_len as usize,
+            )
         }
     }
 }
@@ -832,7 +894,9 @@ impl<'a> Binding for DiffHunk<'a> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *const raw::git_diff_hunk { self.raw }
+    fn raw(&self) -> *const raw::git_diff_hunk {
+        self.raw
+    }
 }
 
 impl DiffStats {
@@ -852,13 +916,15 @@ impl DiffStats {
     }
 
     /// Print diff statistics to a Buf
-    pub fn to_buf(&self, format: DiffStatsFormat, width: usize)
-                  -> Result<Buf, Error> {
+    pub fn to_buf(&self, format: DiffStatsFormat, width: usize) -> Result<Buf, Error> {
         let buf = Buf::new();
         unsafe {
-            try_call!(raw::git_diff_stats_to_buf(buf.raw(), self.raw,
-                                                 format.bits(),
-                                                 width as size_t));
+            try_call!(raw::git_diff_stats_to_buf(
+                buf.raw(),
+                self.raw,
+                format.bits(),
+                width as size_t
+            ));
         }
         Ok(buf)
     }
@@ -870,7 +936,9 @@ impl Binding for DiffStats {
     unsafe fn from_raw(raw: *mut raw::git_diff_stats) -> DiffStats {
         DiffStats { raw: raw }
     }
-    fn raw(&self) -> *mut raw::git_diff_stats { self.raw }
+    fn raw(&self) -> *mut raw::git_diff_stats {
+        self.raw
+    }
 }
 
 impl Drop for DiffStats {
@@ -909,7 +977,9 @@ impl<'a> Binding for DiffBinary<'a> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *const raw::git_diff_binary { self.raw }
+    fn raw(&self) -> *const raw::git_diff_binary {
+        self.raw
+    }
 }
 
 impl<'a> DiffBinaryFile<'a> {
@@ -921,8 +991,7 @@ impl<'a> DiffBinaryFile<'a> {
     /// The binary data, deflated
     pub fn data(&self) -> &[u8] {
         unsafe {
-            slice::from_raw_parts((*self.raw).data as *const u8,
-                                  (*self.raw).datalen as usize)
+            slice::from_raw_parts((*self.raw).data as *const u8, (*self.raw).datalen as usize)
         }
     }
 
@@ -930,7 +999,6 @@ impl<'a> DiffBinaryFile<'a> {
     pub fn inflated_len(&self) -> usize {
         unsafe { (*self.raw).inflatedlen as usize }
     }
-
 }
 
 impl<'a> Binding for DiffBinaryFile<'a> {
@@ -941,7 +1009,9 @@ impl<'a> Binding for DiffBinaryFile<'a> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *const raw::git_diff_binary_file { self.raw }
+    fn raw(&self) -> *const raw::git_diff_binary_file {
+        self.raw
+    }
 }
 
 impl Binding for DiffBinaryKind {
@@ -978,9 +1048,10 @@ impl DiffFindOptions {
         let mut opts = DiffFindOptions {
             raw: unsafe { mem::zeroed() },
         };
-        assert_eq!(unsafe {
-            raw::git_diff_find_init_options(&mut opts.raw, 1)
-        }, 0);
+        assert_eq!(
+            unsafe { raw::git_diff_find_init_options(&mut opts.raw, 1) },
+            0
+        );
         opts
     }
 
@@ -1019,8 +1090,7 @@ impl DiffFindOptions {
     ///
     /// For this to work correctly, use `include_unmodified` when the initial
     /// diff is being generated.
-    pub fn copies_from_unmodified(&mut self, find: bool)
-                                  -> &mut DiffFindOptions {
+    pub fn copies_from_unmodified(&mut self, find: bool) -> &mut DiffFindOptions {
         self.flag(raw::GIT_DIFF_FIND_COPIES_FROM_UNMODIFIED, find)
     }
 
@@ -1053,8 +1123,7 @@ impl DiffFindOptions {
     }
 
     /// Measure similarity ignoring leading whitespace (default)
-    pub fn ignore_leading_whitespace(&mut self, ignore: bool)
-                                     -> &mut DiffFindOptions {
+    pub fn ignore_leading_whitespace(&mut self, ignore: bool) -> &mut DiffFindOptions {
         self.flag(raw::GIT_DIFF_FIND_IGNORE_LEADING_WHITESPACE, ignore)
     }
 
@@ -1083,8 +1152,7 @@ impl DiffFindOptions {
     /// If you add this flag in and the split pair is not used for an actual
     /// rename or copy, then the modified record will be restored to a regular
     /// modified record instead of being split.
-    pub fn break_rewrites_for_renames_only(&mut self, b: bool)
-                                           -> &mut DiffFindOptions {
+    pub fn break_rewrites_for_renames_only(&mut self, b: bool) -> &mut DiffFindOptions {
         self.flag(raw::GIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY, b)
     }
 
@@ -1105,8 +1173,7 @@ impl DiffFindOptions {
     }
 
     /// Similarity of modified to be glegible rename source (default 50)
-    pub fn rename_from_rewrite_threshold(&mut self, thresh: u16)
-                                         -> &mut DiffFindOptions {
+    pub fn rename_from_rewrite_threshold(&mut self, thresh: u16) -> &mut DiffFindOptions {
         self.raw.rename_from_rewrite_threshold = thresh;
         self
     }
@@ -1118,8 +1185,7 @@ impl DiffFindOptions {
     }
 
     /// Similarity to split modify into delete/add pair (default 60)
-    pub fn break_rewrite_threshold(&mut self, thresh: u16)
-                                   -> &mut DiffFindOptions {
+    pub fn break_rewrite_threshold(&mut self, thresh: u16) -> &mut DiffFindOptions {
         self.raw.break_rewrite_threshold = thresh;
         self
     }
@@ -1160,8 +1226,15 @@ mod tests {
         let (_td, repo) = ::test::repo_init();
         let diff = t!(repo.diff_tree_to_workdir(None, None));
         let mut count = 0;
-        t!(diff.foreach(&mut |_file, _progress| { count = count + 1; true },
-                        None, None, None));
+        t!(diff.foreach(
+            &mut |_file, _progress| {
+                count = count + 1;
+                true
+            },
+            None,
+            None,
+            None
+        ));
         assert_eq!(count, 0);
     }
 
@@ -1175,11 +1248,16 @@ mod tests {
         let diff = t!(repo.diff_tree_to_workdir(None, Some(&mut opts)));
         let mut count = 0;
         let mut result = None;
-        t!(diff.foreach(&mut |file, _progress| {
-            count = count + 1;
-            result = file.new_file().path().map(ToOwned::to_owned);
-            true
-        }, None, None, None));
+        t!(diff.foreach(
+            &mut |file, _progress| {
+                count = count + 1;
+                result = file.new_file().path().map(ToOwned::to_owned);
+                true
+            },
+            None,
+            None,
+            None
+        ));
         assert_eq!(result.as_ref().map(Borrow::borrow), Some(path));
         assert_eq!(count, 1);
     }
@@ -1193,8 +1271,7 @@ mod tests {
         t!(index.add_path(path));
         let mut opts = DiffOptions::new();
         opts.include_untracked(true);
-        let diff = t!(repo.diff_tree_to_index(None, Some(&index),
-                                              Some(&mut opts)));
+        let diff = t!(repo.diff_tree_to_index(None, Some(&index), Some(&mut opts)));
         let mut new_lines = 0;
         t!(diff.foreach(
             &mut |_file, _progress| { true },
@@ -1203,7 +1280,8 @@ mod tests {
                 new_lines = hunk.new_lines();
                 true
             }),
-            None));
+            None
+        ));
         assert_eq!(new_lines, 1);
     }
 
@@ -1212,8 +1290,7 @@ mod tests {
         let fib = vec![0, 1, 1, 2, 3, 5, 8];
         // Verified with a node implementation of deflate, might be worth
         // adding a deflate lib to do this inline here.
-        let deflated_fib = vec![120, 156, 99, 96, 100, 100, 98, 102, 229, 0, 0,
-                                0, 53, 0, 21];
+        let deflated_fib = vec![120, 156, 99, 96, 100, 100, 98, 102, 229, 0, 0, 0, 53, 0, 21];
         let foo_path = Path::new("foo");
         let bin_path = Path::new("bin");
         let (td, repo) = ::test::repo_init();
@@ -1224,8 +1301,7 @@ mod tests {
         t!(index.add_path(bin_path));
         let mut opts = DiffOptions::new();
         opts.include_untracked(true).show_binary(true);
-        let diff = t!(repo.diff_tree_to_index(None, Some(&index),
-                                              Some(&mut opts)));
+        let diff = t!(repo.diff_tree_to_index(None, Some(&index), Some(&mut opts)));
         let mut bin_content = None;
         let mut new_lines = 0;
         let mut line_content = None;
@@ -1242,7 +1318,8 @@ mod tests {
             Some(&mut |_file, _hunk, line| {
                 line_content = String::from_utf8(line.content().into()).ok();
                 true
-            })));
+            })
+        ));
         assert_eq!(bin_content, Some(deflated_fib));
         assert_eq!(new_lines, 1);
         assert_eq!(line_content, Some("bar\n".to_string()));

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use libc::c_int;
 use {raw, ErrorClass, ErrorCode};
 
 /// A structure to represent errors coming out of libgit2.
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Error {
     code: c_int,
     klass: c_int,
@@ -32,7 +32,11 @@ impl Error {
     unsafe fn from_raw(code: c_int, ptr: *const raw::git_error) -> Error {
         let msg = CStr::from_ptr((*ptr).message as *const _).to_bytes();
         let msg = str::from_utf8(msg).unwrap();
-        Error { code: code, klass: (*ptr).klass, message: msg.to_string() }
+        Error {
+            code: code,
+            klass: (*ptr).klass,
+            message: msg.to_string(),
+        }
     }
 
     /// Creates a new error from the given string as the error.
@@ -194,11 +198,15 @@ impl Error {
     }
 
     /// Return the message associated with this error
-    pub fn message(&self) -> &str { &self.message }
+    pub fn message(&self) -> &str {
+        &self.message
+    }
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str { &self.message }
+    fn description(&self) -> &str {
+        &self.message
+    }
 }
 
 impl fmt::Display for Error {
@@ -210,8 +218,10 @@ impl fmt::Display for Error {
 
 impl From<NulError> for Error {
     fn from(_: NulError) -> Error {
-        Error::from_str("data contained a nul byte that could not be \
-                         represented as a string")
+        Error::from_str(
+            "data contained a nul byte that could not be \
+             represented as a string",
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,13 @@
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
+#[macro_use]
+extern crate bitflags;
 extern crate libc;
-extern crate url;
 extern crate libgit2_sys as raw;
-#[macro_use] extern crate bitflags;
-#[cfg(test)] extern crate tempdir;
+#[cfg(test)]
+extern crate tempdir;
+extern crate url;
 
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -84,39 +86,39 @@ pub use blob::{Blob, BlobWriter};
 pub use branch::{Branch, Branches};
 pub use buf::Buf;
 pub use commit::{Commit, Parents};
-pub use config::{Config, ConfigEntry, ConfigEntries};
+pub use config::{Config, ConfigEntries, ConfigEntry};
 pub use cred::{Cred, CredentialHelper};
 pub use describe::{Describe, DescribeFormatOptions, DescribeOptions};
-pub use diff::{Diff, DiffDelta, DiffFile, DiffOptions, Deltas};
+pub use diff::{Deltas, Diff, DiffDelta, DiffFile, DiffOptions};
 pub use diff::{DiffBinary, DiffBinaryFile, DiffBinaryKind};
-pub use diff::{DiffLine, DiffHunk, DiffStats, DiffFindOptions};
+pub use diff::{DiffFindOptions, DiffHunk, DiffLine, DiffStats};
 pub use error::Error;
-pub use index::{Index, IndexEntry, IndexEntries, IndexMatchedPath};
+pub use index::{Index, IndexEntries, IndexEntry, IndexMatchedPath};
 pub use merge::{AnnotatedCommit, MergeOptions};
 pub use message::{message_prettify, DEFAULT_COMMENT_CHAR};
 pub use note::{Note, Notes};
 pub use object::Object;
 pub use oid::Oid;
 pub use packbuilder::{PackBuilder, PackBuilderStage};
-pub use pathspec::{Pathspec, PathspecMatchList, PathspecFailedEntries};
+pub use pathspec::{Pathspec, PathspecFailedEntries, PathspecMatchList};
 pub use pathspec::{PathspecDiffEntries, PathspecEntries};
 pub use patch::Patch;
 pub use proxy_options::ProxyOptions;
-pub use reference::{Reference, References, ReferenceNames};
+pub use reference::{Reference, ReferenceNames, References};
 pub use reflog::{Reflog, ReflogEntry, ReflogIter};
 pub use refspec::Refspec;
-pub use remote::{Remote, RemoteConnection, Refspecs, RemoteHead, FetchOptions, PushOptions};
-pub use remote_callbacks::{RemoteCallbacks, Credentials, TransferProgress};
-pub use remote_callbacks::{TransportMessage, Progress, UpdateTips};
+pub use remote::{FetchOptions, PushOptions, Refspecs, Remote, RemoteConnection, RemoteHead};
+pub use remote_callbacks::{Credentials, RemoteCallbacks, TransferProgress};
+pub use remote_callbacks::{Progress, TransportMessage, UpdateTips};
 pub use repo::{Repository, RepositoryInitOptions};
 pub use revspec::Revspec;
 pub use revwalk::Revwalk;
 pub use signature::Signature;
-pub use status::{StatusOptions, Statuses, StatusIter, StatusEntry, StatusShow};
-pub use stash::{StashApplyOptions, StashCb, StashApplyProgressCb};
+pub use status::{StatusEntry, StatusIter, StatusOptions, StatusShow, Statuses};
+pub use stash::{StashApplyOptions, StashApplyProgressCb, StashCb};
 pub use submodule::{Submodule, SubmoduleUpdateOptions};
 pub use tag::Tag;
-pub use time::{Time, IndexTime};
+pub use time::{IndexTime, Time};
 pub use tree::{Tree, TreeEntry, TreeIter};
 pub use treebuilder::TreeBuilder;
 pub use odb::{Odb, OdbReader, OdbWriter};
@@ -519,8 +521,11 @@ bitflags! {
     }
 }
 
-#[cfg(test)] #[macro_use] mod test;
-#[macro_use] mod panic;
+#[cfg(test)]
+#[macro_use]
+mod test;
+#[macro_use]
+mod panic;
 mod call;
 mod util;
 
@@ -699,8 +704,7 @@ fn openssl_env_init() {
 #[cfg(any(windows, target_os = "macos", target_os = "ios", not(feature = "https")))]
 fn openssl_env_init() {}
 
-unsafe fn opt_bytes<T>(_anchor: &T,
-                           c: *const libc::c_char) -> Option<&[u8]> {
+unsafe fn opt_bytes<T>(_anchor: &T, c: *const libc::c_char) -> Option<&[u8]> {
     if c.is_null() {
         None
     } else {
@@ -711,7 +715,7 @@ unsafe fn opt_bytes<T>(_anchor: &T,
 fn opt_cstr<T: IntoCString>(o: Option<T>) -> Result<Option<CString>, Error> {
     match o {
         Some(s) => s.into_c_string().map(Some),
-        None => Ok(None)
+        None => Ok(None),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,8 +699,8 @@ fn openssl_env_init() {
 #[cfg(any(windows, target_os = "macos", target_os = "ios", not(feature = "https")))]
 fn openssl_env_init() {}
 
-unsafe fn opt_bytes<'a, T>(_anchor: &'a T,
-                           c: *const libc::c_char) -> Option<&'a [u8]> {
+unsafe fn opt_bytes<T>(_anchor: &T,
+                           c: *const libc::c_char) -> Option<&[u8]> {
     if c.is_null() {
         None
     } else {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -2,7 +2,7 @@ use std::marker;
 use std::mem;
 use libc::c_uint;
 
-use {raw, Oid, Commit, FileFavor};
+use {raw, Commit, FileFavor, Oid};
 use util::Binding;
 use call::Convert;
 
@@ -40,9 +40,7 @@ impl MergeOptions {
         let mut opts = MergeOptions {
             raw: unsafe { mem::zeroed() },
         };
-        assert_eq!(unsafe {
-            raw::git_merge_init_options(&mut opts.raw, 1)
-        }, 0);
+        assert_eq!(unsafe { raw::git_merge_init_options(&mut opts.raw, 1) }, 0);
         opts
     }
 
@@ -143,14 +141,15 @@ impl MergeOptions {
 
 impl<'repo> Binding for AnnotatedCommit<'repo> {
     type Raw = *mut raw::git_annotated_commit;
-    unsafe fn from_raw(raw: *mut raw::git_annotated_commit)
-                       -> AnnotatedCommit<'repo> {
+    unsafe fn from_raw(raw: *mut raw::git_annotated_commit) -> AnnotatedCommit<'repo> {
         AnnotatedCommit {
             raw: raw,
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_annotated_commit { self.raw }
+    fn raw(&self) -> *mut raw::git_annotated_commit {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for AnnotatedCommit<'repo> {

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,18 +8,22 @@ use util::Binding;
 /// Clean up a message, removing extraneous whitespace, and ensure that the
 /// message ends with a newline. If `comment_char` is `Some`, also remove comment
 /// lines starting with that character.
-pub fn message_prettify<T: IntoCString>(message: T, comment_char: Option<u8>)
-                                        -> Result<String, Error> {
+pub fn message_prettify<T: IntoCString>(
+    message: T,
+    comment_char: Option<u8>,
+) -> Result<String, Error> {
     _message_prettify(try!(message.into_c_string()), comment_char)
 }
 
-fn _message_prettify(message: CString, comment_char: Option<u8>)
-                     -> Result<String, Error> {
+fn _message_prettify(message: CString, comment_char: Option<u8>) -> Result<String, Error> {
     let ret = Buf::new();
     unsafe {
-        try_call!(raw::git_message_prettify(ret.raw(), message,
-                                            comment_char.is_some() as c_int,
-                                            comment_char.unwrap_or(0) as c_char));
+        try_call!(raw::git_message_prettify(
+            ret.raw(),
+            message,
+            comment_char.is_some() as c_int,
+            comment_char.unwrap_or(0) as c_char
+        ));
     }
     Ok(ret.as_str().unwrap().to_string())
 }
@@ -36,17 +40,22 @@ mod tests {
         // This does not attempt to duplicate the extensive tests for
         // git_message_prettify in libgit2, just a few representative values to
         // make sure the interface works as expected.
-        assert_eq!(message_prettify("1\n\n\n2", None).unwrap(),
-                   "1\n\n2\n");
-        assert_eq!(message_prettify("1\n\n\n2\n\n\n3", None).unwrap(),
-                   "1\n\n2\n\n3\n");
-        assert_eq!(message_prettify("1\n# comment\n# more", None).unwrap(),
-                   "1\n# comment\n# more\n");
-        assert_eq!(message_prettify("1\n# comment\n# more",
-                                    DEFAULT_COMMENT_CHAR).unwrap(),
-                   "1\n");
-        assert_eq!(message_prettify("1\n; comment\n; more",
-                                    Some(';' as u8)).unwrap(),
-                   "1\n");
+        assert_eq!(message_prettify("1\n\n\n2", None).unwrap(), "1\n\n2\n");
+        assert_eq!(
+            message_prettify("1\n\n\n2\n\n\n3", None).unwrap(),
+            "1\n\n2\n\n3\n"
+        );
+        assert_eq!(
+            message_prettify("1\n# comment\n# more", None).unwrap(),
+            "1\n# comment\n# more\n"
+        );
+        assert_eq!(
+            message_prettify("1\n# comment\n# more", DEFAULT_COMMENT_CHAR).unwrap(),
+            "1\n"
+        );
+        assert_eq!(
+            message_prettify("1\n; comment\n; more", Some(';' as u8)).unwrap(),
+            "1\n"
+        );
     }
 }

--- a/src/note.rs
+++ b/src/note.rs
@@ -1,7 +1,7 @@
 use std::marker;
 use std::str;
 
-use {raw, signature, Signature, Oid, Repository, Error};
+use {raw, signature, Error, Oid, Repository, Signature};
 use util::Binding;
 
 /// A structure representing a [note][note] in git.
@@ -25,16 +25,12 @@ pub struct Notes<'repo> {
 impl<'repo> Note<'repo> {
     /// Get the note author
     pub fn author(&self) -> Signature {
-        unsafe {
-            signature::from_raw_const(self, raw::git_note_author(&*self.raw))
-        }
+        unsafe { signature::from_raw_const(self, raw::git_note_author(&*self.raw)) }
     }
 
     /// Get the note committer
     pub fn committer(&self) -> Signature {
-        unsafe {
-            signature::from_raw_const(self, raw::git_note_committer(&*self.raw))
-        }
+        unsafe { signature::from_raw_const(self, raw::git_note_committer(&*self.raw)) }
     }
 
     /// Get the note message, in bytes.
@@ -56,9 +52,14 @@ impl<'repo> Note<'repo> {
 impl<'repo> Binding for Note<'repo> {
     type Raw = *mut raw::git_note;
     unsafe fn from_raw(raw: *mut raw::git_note) -> Note<'repo> {
-        Note { raw: raw, _marker: marker::PhantomData, }
+        Note {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_note { self.raw }
+    fn raw(&self) -> *mut raw::git_note {
+        self.raw
+    }
 }
 
 impl<'repo> ::std::fmt::Debug for Note<'repo> {
@@ -69,35 +70,51 @@ impl<'repo> ::std::fmt::Debug for Note<'repo> {
 
 impl<'repo> Drop for Note<'repo> {
     fn drop(&mut self) {
-        unsafe { raw::git_note_free(self.raw); }
+        unsafe {
+            raw::git_note_free(self.raw);
+        }
     }
 }
 
 impl<'repo> Binding for Notes<'repo> {
     type Raw = *mut raw::git_note_iterator;
     unsafe fn from_raw(raw: *mut raw::git_note_iterator) -> Notes<'repo> {
-        Notes { raw: raw, _marker: marker::PhantomData, }
+        Notes {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_note_iterator { self.raw }
+    fn raw(&self) -> *mut raw::git_note_iterator {
+        self.raw
+    }
 }
 
 impl<'repo> Iterator for Notes<'repo> {
     type Item = Result<(Oid, Oid), Error>;
     fn next(&mut self) -> Option<Result<(Oid, Oid), Error>> {
-        let mut note_id = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut note_id = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         let mut annotated_id = note_id;
         unsafe {
-            try_call_iter!(raw::git_note_next(&mut note_id, &mut annotated_id,
-                                              self.raw));
-            Some(Ok((Binding::from_raw(&note_id as *const _),
-                     Binding::from_raw(&annotated_id as *const _))))
+            try_call_iter!(raw::git_note_next(
+                &mut note_id,
+                &mut annotated_id,
+                self.raw
+            ));
+            Some(Ok((
+                Binding::from_raw(&note_id as *const _),
+                Binding::from_raw(&annotated_id as *const _),
+            )))
         }
     }
 }
 
 impl<'repo> Drop for Notes<'repo> {
     fn drop(&mut self) {
-        unsafe { raw::git_note_iterator_free(self.raw); }
+        unsafe {
+            raw::git_note_iterator_free(self.raw);
+        }
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -167,7 +167,7 @@ impl<'repo> Object<'repo> {
     }
 }
 
-/// This trait is useful to export cast_or_panic into crate but not outside
+/// This trait is useful to export `cast_or_panic` into crate but not outside
 pub trait CastOrPanic {
     fn cast_or_panic<T>(self, kind: ObjectType) -> T;
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -2,7 +2,7 @@ use std::marker;
 use std::mem;
 use std::ptr;
 
-use {raw, Oid, ObjectType, Error, Buf, Commit, Tag, Blob, Tree, Repository};
+use {raw, Blob, Buf, Commit, Error, ObjectType, Oid, Repository, Tag, Tree};
 use {Describe, DescribeOptions};
 use util::Binding;
 
@@ -17,9 +17,7 @@ pub struct Object<'repo> {
 impl<'repo> Object<'repo> {
     /// Get the id (SHA1) of a repository object
     pub fn id(&self) -> Oid {
-        unsafe {
-            Binding::from_raw(raw::git_object_id(&*self.raw))
-        }
+        unsafe { Binding::from_raw(raw::git_object_id(&*self.raw)) }
     }
 
     /// Get the object type of an object.
@@ -44,22 +42,26 @@ impl<'repo> Object<'repo> {
 
     /// Recursively peel an object until a blob is found
     pub fn peel_to_blob(&self) -> Result<Blob, Error> {
-        self.peel(ObjectType::Blob).map(|o| o.cast_or_panic(ObjectType::Blob))
+        self.peel(ObjectType::Blob)
+            .map(|o| o.cast_or_panic(ObjectType::Blob))
     }
 
     /// Recursively peel an object until a commit is found
     pub fn peel_to_commit(&self) -> Result<Commit, Error> {
-        self.peel(ObjectType::Commit).map(|o| o.cast_or_panic(ObjectType::Commit))
+        self.peel(ObjectType::Commit)
+            .map(|o| o.cast_or_panic(ObjectType::Commit))
     }
 
     /// Recursively peel an object until a tag is found
     pub fn peel_to_tag(&self) -> Result<Tag, Error> {
-        self.peel(ObjectType::Tag).map(|o| o.cast_or_panic(ObjectType::Tag))
+        self.peel(ObjectType::Tag)
+            .map(|o| o.cast_or_panic(ObjectType::Tag))
     }
 
     /// Recursively peel an object until a tree is found
     pub fn peel_to_tree(&self) -> Result<Tree, Error> {
-        self.peel(ObjectType::Tree).map(|o| o.cast_or_panic(ObjectType::Tree))
+        self.peel(ObjectType::Tree)
+            .map(|o| o.cast_or_panic(ObjectType::Tree))
     }
 
     /// Get a short abbreviated OID string for the object
@@ -135,8 +137,7 @@ impl<'repo> Object<'repo> {
     /// Describes a commit
     ///
     /// Performs a describe operation on this commitish object.
-    pub fn describe(&self, opts: &DescribeOptions)
-                    -> Result<Describe, Error> {
+    pub fn describe(&self, opts: &DescribeOptions) -> Result<Describe, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
             try_call!(raw::git_describe_commit(&mut ret, self.raw, opts.raw()));
@@ -190,7 +191,12 @@ impl<'repo> CastOrPanic for Object<'repo> {
                     &buf
                 }
             };
-            panic!("Expected object {} to be {} but it is {}", self.id(), kind.str(), akind)
+            panic!(
+                "Expected object {} to be {} but it is {}",
+                self.id(),
+                kind.str(),
+                akind
+            )
         }
     }
 }
@@ -211,7 +217,10 @@ impl<'repo> ::std::fmt::Debug for Object<'repo> {
         let mut ds = f.debug_struct("Object");
         match self.kind() {
             Some(kind) => ds.field("kind", &kind),
-            None => ds.field("kind", &format!("Unknow ({})", unsafe { raw::git_object_type(&*self.raw) }))
+            None => ds.field(
+                "kind",
+                &format!("Unknow ({})", unsafe { raw::git_object_type(&*self.raw) }),
+            ),
         };
         ds.field("id", &self.id());
         ds.finish()
@@ -222,9 +231,14 @@ impl<'repo> Binding for Object<'repo> {
     type Raw = *mut raw::git_object;
 
     unsafe fn from_raw(raw: *mut raw::git_object) -> Object<'repo> {
-        Object { raw: raw, _marker: marker::PhantomData, }
+        Object {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_object { self.raw }
+    fn raw(&self) -> *mut raw::git_object {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Object<'repo> {

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::cmp::Ordering;
-use std::hash::{Hasher, Hash};
+use std::hash::{Hash, Hasher};
 use std::str;
 use libc;
 
@@ -20,12 +20,15 @@ impl Oid {
     /// returned.
     pub fn from_str(s: &str) -> Result<Oid, Error> {
         ::init();
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_oid_fromstrn(&mut raw,
-                                            s.as_bytes().as_ptr()
-                                                as *const libc::c_char,
-                                            s.len() as libc::size_t));
+            try_call!(raw::git_oid_fromstrn(
+                &mut raw,
+                s.as_bytes().as_ptr() as *const libc::c_char,
+                s.len() as libc::size_t
+            ));
         }
         Ok(Oid { raw: raw })
     }
@@ -35,7 +38,9 @@ impl Oid {
     /// If the array given is not 20 bytes in length, an error is returned.
     pub fn from_bytes(bytes: &[u8]) -> Result<Oid, Error> {
         ::init();
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         if bytes.len() != raw::GIT_OID_RAWSZ {
             Err(Error::from_str("raw byte array must be 20 bytes"))
         } else {
@@ -45,7 +50,9 @@ impl Oid {
     }
 
     /// View this OID as a byte-slice 20 bytes in length.
-    pub fn as_bytes(&self) -> &[u8] { &self.raw.id }
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.raw.id
+    }
 
     /// Test if this OID is all zeros.
     pub fn is_zero(&self) -> bool {
@@ -59,7 +66,9 @@ impl Binding for Oid {
     unsafe fn from_raw(oid: *const raw::git_oid) -> Oid {
         Oid { raw: *oid }
     }
-    fn raw(&self) -> *const raw::git_oid { &self.raw as *const _ }
+    fn raw(&self) -> *const raw::git_oid {
+        &self.raw as *const _
+    }
 }
 
 impl fmt::Debug for Oid {
@@ -73,8 +82,11 @@ impl fmt::Display for Oid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut dst = [0u8; raw::GIT_OID_HEXSZ + 1];
         unsafe {
-            raw::git_oid_tostr(dst.as_mut_ptr() as *mut libc::c_char,
-                               dst.len() as libc::size_t, &self.raw);
+            raw::git_oid_tostr(
+                dst.as_mut_ptr() as *mut libc::c_char,
+                dst.len() as libc::size_t,
+                &self.raw,
+            );
         }
         let s = &dst[..dst.iter().position(|&a| a == 0).unwrap()];
         str::from_utf8(s).unwrap().fmt(f)
@@ -123,7 +135,9 @@ impl Hash for Oid {
 }
 
 impl AsRef<[u8]> for Oid {
-    fn as_ref(&self) -> &[u8] { self.as_bytes() }
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
 }
 
 #[cfg(test)]

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -23,7 +23,7 @@ impl Deref for OidArray {
     fn deref(&self) -> &[Oid] {
         unsafe {
             debug_assert_eq!(mem::size_of::<Oid>(), mem::size_of_val(&*self.raw.ids));
-            
+
             slice::from_raw_parts(self.raw.ids as *const Oid, self.raw.count as usize)
         }
     }
@@ -34,12 +34,14 @@ impl Binding for OidArray {
     unsafe fn from_raw(raw: raw::git_oidarray) -> OidArray {
         OidArray { raw: raw }
     }
-    fn raw(&self) -> raw::git_oidarray { self.raw }
+    fn raw(&self) -> raw::git_oidarray {
+        self.raw
+    }
 }
 
 impl<'repo> ::std::fmt::Debug for OidArray {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-		f.debug_tuple("OidArray").field(&self.deref()).finish()
+        f.debug_tuple("OidArray").field(&self.deref()).finish()
     }
 }
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -9,7 +9,7 @@ thread_local!(static LAST_ERROR: RefCell<Option<Box<Any + Send>>> = {
 pub fn wrap<T, F: FnOnce() -> T + ::std::panic::UnwindSafe>(f: F) -> Option<T> {
     use std::panic;
     if LAST_ERROR.with(|slot| slot.borrow().is_some()) {
-        return None
+        return None;
     }
     match panic::catch_unwind(f) {
         Ok(ret) => Some(ret),
@@ -30,11 +30,12 @@ pub fn wrap<T, F: FnOnce() -> T>(f: F) -> Option<T> {
     impl Drop for Bomb {
         fn drop(&mut self) {
             if !self.enabled {
-                return
+                return;
             }
-            panic!("callback has panicked, and continuing to unwind into C \
-                    is not safe, so aborting the process");
-
+            panic!(
+                "callback has panicked, and continuing to unwind into C \
+                 is not safe, so aborting the process"
+            );
         }
     }
     let mut bomb = Bomb { enabled: true };

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -3,8 +3,8 @@ use std::ptr;
 use libc::{c_char, c_int, c_void};
 
 use {raw, Blob, Buf, Diff, DiffDelta, DiffHunk, DiffLine, DiffOptions, Error};
-use diff::{LineCb, print_cb};
-use util::{Binding, into_opt_c_string};
+use diff::{print_cb, LineCb};
+use util::{into_opt_c_string, Binding};
 
 /// A structure representing the text changes in a single diff delta.
 ///
@@ -20,7 +20,9 @@ impl Binding for Patch {
     unsafe fn from_raw(raw: Self::Raw) -> Patch {
         Patch { raw: raw }
     }
-    fn raw(&self) -> Self::Raw { self.raw }
+    fn raw(&self) -> Self::Raw {
+        self.raw
+    }
 }
 
 impl Drop for Patch {
@@ -42,86 +44,88 @@ impl Patch {
     }
 
     /// Generate a Patch by diffing two blobs.
-    pub fn from_blobs(old_blob: &Blob,
-                      old_path: Option<&Path>,
-                      new_blob: &Blob,
-                      new_path: Option<&Path>,
-                      opts: Option<&mut DiffOptions>)
-                      -> Result<Patch, Error>
-    {
+    pub fn from_blobs(
+        old_blob: &Blob,
+        old_path: Option<&Path>,
+        new_blob: &Blob,
+        new_path: Option<&Path>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Patch, Error> {
         let mut ret = ptr::null_mut();
         let old_path = try!(into_opt_c_string(old_path));
         let new_path = try!(into_opt_c_string(new_path));
         unsafe {
-            try_call!(raw::git_patch_from_blobs(&mut ret,
-                                                old_blob.raw(),
-                                                old_path,
-                                                new_blob.raw(),
-                                                new_path,
-                                                opts.map(|s| s.raw())));
+            try_call!(raw::git_patch_from_blobs(
+                &mut ret,
+                old_blob.raw(),
+                old_path,
+                new_blob.raw(),
+                new_path,
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
 
     /// Generate a Patch by diffing a blob and a buffer.
-    pub fn from_blob_and_buffer(old_blob: &Blob,
-                                old_path: Option<&Path>,
-                                new_buffer: &[u8],
-                                new_path: Option<&Path>,
-                                opts: Option<&mut DiffOptions>)
-                                -> Result<Patch, Error>
-    {
+    pub fn from_blob_and_buffer(
+        old_blob: &Blob,
+        old_path: Option<&Path>,
+        new_buffer: &[u8],
+        new_path: Option<&Path>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Patch, Error> {
         let mut ret = ptr::null_mut();
         let old_path = try!(into_opt_c_string(old_path));
         let new_path = try!(into_opt_c_string(new_path));
         unsafe {
-            try_call!(raw::git_patch_from_blob_and_buffer(&mut ret,
-                                                          old_blob.raw(),
-                                                          old_path,
-                                                          new_buffer.as_ptr() as *const c_char,
-                                                          new_buffer.len(),
-                                                          new_path,
-                                                          opts.map(|s| s.raw())));
+            try_call!(raw::git_patch_from_blob_and_buffer(
+                &mut ret,
+                old_blob.raw(),
+                old_path,
+                new_buffer.as_ptr() as *const c_char,
+                new_buffer.len(),
+                new_path,
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
 
     /// Generate a Patch by diffing two buffers.
-    pub fn from_buffers(old_buffer: &[u8],
-                        old_path: Option<&Path>,
-                        new_buffer: &[u8],
-                        new_path: Option<&Path>,
-                        opts: Option<&mut DiffOptions>)
-                        -> Result<Patch, Error>
-    {
+    pub fn from_buffers(
+        old_buffer: &[u8],
+        old_path: Option<&Path>,
+        new_buffer: &[u8],
+        new_path: Option<&Path>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Patch, Error> {
         let mut ret = ptr::null_mut();
         let old_path = try!(into_opt_c_string(old_path));
         let new_path = try!(into_opt_c_string(new_path));
         unsafe {
-            try_call!(raw::git_patch_from_buffers(&mut ret,
-                                                 old_buffer.as_ptr() as *const c_void,
-                                                 old_buffer.len(),
-                                                 old_path,
-                                                 new_buffer.as_ptr() as *const c_char,
-                                                 new_buffer.len(),
-                                                 new_path,
-                                                 opts.map(|s| s.raw())));
+            try_call!(raw::git_patch_from_buffers(
+                &mut ret,
+                old_buffer.as_ptr() as *const c_void,
+                old_buffer.len(),
+                old_path,
+                new_buffer.as_ptr() as *const c_char,
+                new_buffer.len(),
+                new_path,
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
 
     /// Get the DiffDelta associated with the Patch.
     pub fn delta(&self) -> DiffDelta {
-        unsafe {
-            Binding::from_raw(raw::git_patch_get_delta(self.raw) as *mut _)
-        }
+        unsafe { Binding::from_raw(raw::git_patch_get_delta(self.raw) as *mut _) }
     }
 
     /// Get the number of hunks in the Patch.
     pub fn num_hunks(&self) -> usize {
-        unsafe {
-            raw::git_patch_num_hunks(self.raw)
-        }
+        unsafe { raw::git_patch_num_hunks(self.raw) }
     }
 
     /// Get the number of lines of context, additions, and deletions in the Patch.
@@ -130,10 +134,12 @@ impl Patch {
         let mut additions = 0;
         let mut deletions = 0;
         unsafe {
-            try_call!(raw::git_patch_line_stats(&mut context,
-                                                &mut additions,
-                                                &mut deletions,
-                                                self.raw));
+            try_call!(raw::git_patch_line_stats(
+                &mut context,
+                &mut additions,
+                &mut deletions,
+                self.raw
+            ));
         }
         Ok((context, additions, deletions))
     }
@@ -143,42 +149,53 @@ impl Patch {
         let mut ret = ptr::null();
         let mut lines = 0;
         unsafe {
-            try_call!(raw::git_patch_get_hunk(&mut ret, &mut lines, self.raw, hunk_idx));
+            try_call!(raw::git_patch_get_hunk(
+                &mut ret,
+                &mut lines,
+                self.raw,
+                hunk_idx
+            ));
             Ok((Binding::from_raw(ret), lines))
         }
     }
 
     /// Get the number of lines in a hunk.
     pub fn num_lines_in_hunk(&self, hunk_idx: usize) -> Result<usize, Error> {
-        unsafe {
-            Ok(try_call!(raw::git_patch_num_lines_in_hunk(self.raw, hunk_idx)) as usize)
-        }
+        unsafe { Ok(try_call!(raw::git_patch_num_lines_in_hunk(self.raw, hunk_idx)) as usize) }
     }
 
     /// Get a DiffLine from a hunk of the Patch.
-    pub fn line_in_hunk(&mut self,
-                        hunk_idx: usize,
-                        line_of_hunk: usize) -> Result<DiffLine, Error> {
+    pub fn line_in_hunk(
+        &mut self,
+        hunk_idx: usize,
+        line_of_hunk: usize,
+    ) -> Result<DiffLine, Error> {
         let mut ret = ptr::null();
         unsafe {
-            try_call!(raw::git_patch_get_line_in_hunk(&mut ret,
-                                                      self.raw,
-                                                      hunk_idx,
-                                                      line_of_hunk));
+            try_call!(raw::git_patch_get_line_in_hunk(
+                &mut ret,
+                self.raw,
+                hunk_idx,
+                line_of_hunk
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
 
     /// Get the size of a Patch's diff data in bytes.
-    pub fn size(&self,
-                include_context: bool,
-                include_hunk_headers: bool,
-                include_file_headers: bool) -> usize {
+    pub fn size(
+        &self,
+        include_context: bool,
+        include_hunk_headers: bool,
+        include_file_headers: bool,
+    ) -> usize {
         unsafe {
-            raw::git_patch_size(self.raw,
-                                include_context as c_int,
-                                include_hunk_headers as c_int,
-                                include_file_headers as c_int)
+            raw::git_patch_size(
+                self.raw,
+                include_context as c_int,
+                include_hunk_headers as c_int,
+                include_file_headers as c_int,
+            )
         }
     }
 

--- a/src/pathspec.rs
+++ b/src/pathspec.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::ptr;
 use libc::size_t;
 
-use {raw, Error, Diff, Tree, PathspecFlags, Index, Repository, DiffDelta, IntoCString};
+use {raw, Diff, DiffDelta, Error, Index, IntoCString, PathspecFlags, Repository, Tree};
 use util::Binding;
 
 /// Structure representing a compiled pathspec used for matching against various
@@ -41,7 +41,10 @@ pub struct PathspecFailedEntries<'list> {
 impl Pathspec {
     /// Creates a new pathspec from a list of specs to match against.
     pub fn new<I, T>(specs: I) -> Result<Pathspec, Error>
-                     where T: IntoCString, I: IntoIterator<Item=T> {
+    where
+        T: IntoCString,
+        I: IntoIterator<Item = T>,
+    {
         let (_a, _b, arr) = try!(::util::iter2cstrs(specs));
         unsafe {
             let mut ret = ptr::null_mut();
@@ -56,12 +59,19 @@ impl Pathspec {
     /// pass `PATHSPEC_FAILURES_ONLY` in the flags) and may also contain the
     /// list of pathspecs with no match if the `PATHSPEC_FIND_FAILURES` flag is
     /// specified.
-    pub fn match_diff(&self, diff: &Diff, flags: PathspecFlags)
-                      -> Result<PathspecMatchList, Error> {
+    pub fn match_diff(
+        &self,
+        diff: &Diff,
+        flags: PathspecFlags,
+    ) -> Result<PathspecMatchList, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_pathspec_match_diff(&mut ret, diff.raw(),
-                                                   flags.bits(), self.raw));
+            try_call!(raw::git_pathspec_match_diff(
+                &mut ret,
+                diff.raw(),
+                flags.bits(),
+                self.raw
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -72,12 +82,19 @@ impl Pathspec {
     /// pass `PATHSPEC_FAILURES_ONLY` in the flags) and may also contain the
     /// list of pathspecs with no match if the `PATHSPEC_FIND_FAILURES` flag is
     /// specified.
-    pub fn match_tree(&self, tree: &Tree, flags: PathspecFlags)
-                      -> Result<PathspecMatchList, Error> {
+    pub fn match_tree(
+        &self,
+        tree: &Tree,
+        flags: PathspecFlags,
+    ) -> Result<PathspecMatchList, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_pathspec_match_tree(&mut ret, tree.raw(),
-                                                   flags.bits(), self.raw));
+            try_call!(raw::git_pathspec_match_tree(
+                &mut ret,
+                tree.raw(),
+                flags.bits(),
+                self.raw
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -88,12 +105,19 @@ impl Pathspec {
     /// pass `PATHSPEC_FAILURES_ONLY` in the flags) and may also contain the
     /// list of pathspecs with no match if the `PATHSPEC_FIND_FAILURES` flag is
     /// specified.
-    pub fn match_index(&self, index: &Index, flags: PathspecFlags)
-                       -> Result<PathspecMatchList, Error> {
+    pub fn match_index(
+        &self,
+        index: &Index,
+        flags: PathspecFlags,
+    ) -> Result<PathspecMatchList, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_pathspec_match_index(&mut ret, index.raw(),
-                                                    flags.bits(), self.raw));
+            try_call!(raw::git_pathspec_match_index(
+                &mut ret,
+                index.raw(),
+                flags.bits(),
+                self.raw
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -110,12 +134,19 @@ impl Pathspec {
     /// pass `PATHSPEC_FAILURES_ONLY` in the flags) and may also contain the
     /// list of pathspecs with no match if the `PATHSPEC_FIND_FAILURES` flag is
     /// specified.
-    pub fn match_workdir(&self, repo: &Repository, flags: PathspecFlags)
-                         -> Result<PathspecMatchList, Error> {
+    pub fn match_workdir(
+        &self,
+        repo: &Repository,
+        flags: PathspecFlags,
+    ) -> Result<PathspecMatchList, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_pathspec_match_workdir(&mut ret, repo.raw(),
-                                                      flags.bits(), self.raw));
+            try_call!(raw::git_pathspec_match_workdir(
+                &mut ret,
+                repo.raw(),
+                flags.bits(),
+                self.raw
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -128,10 +159,7 @@ impl Pathspec {
     /// back on being case sensitive.
     pub fn matches_path(&self, path: &Path, flags: PathspecFlags) -> bool {
         let path = path.into_c_string().unwrap();
-        unsafe {
-            raw::git_pathspec_matches_path(&*self.raw, flags.bits(),
-                                           path.as_ptr()) == 1
-        }
+        unsafe { raw::git_pathspec_matches_path(&*self.raw, flags.bits(), path.as_ptr()) == 1 }
     }
 }
 
@@ -141,7 +169,9 @@ impl Binding for Pathspec {
     unsafe fn from_raw(raw: *mut raw::git_pathspec) -> Pathspec {
         Pathspec { raw: raw }
     }
-    fn raw(&self) -> *mut raw::git_pathspec { self.raw }
+    fn raw(&self) -> *mut raw::git_pathspec {
+        self.raw
+    }
 }
 
 impl Drop for Pathspec {
@@ -162,8 +192,15 @@ impl<'ps> PathspecMatchList<'ps> {
     /// Returns an iterator over the matching filenames in this list.
     pub fn entries(&self) -> PathspecEntries {
         let n = self.entrycount();
-        let n = if n > 0 && self.entry(0).is_none() {0} else {n};
-        PathspecEntries { range: 0..n, list: self }
+        let n = if n > 0 && self.entry(0).is_none() {
+            0
+        } else {
+            n
+        };
+        PathspecEntries {
+            range: 0..n,
+            list: self,
+        }
     }
 
     /// Get a matching filename by position.
@@ -180,8 +217,15 @@ impl<'ps> PathspecMatchList<'ps> {
     /// Returns an iterator over the matching diff entries in this list.
     pub fn diff_entries(&self) -> PathspecDiffEntries {
         let n = self.entrycount();
-        let n = if n > 0 && self.diff_entry(0).is_none() {0} else {n};
-        PathspecDiffEntries { range: 0..n, list: self }
+        let n = if n > 0 && self.diff_entry(0).is_none() {
+            0
+        } else {
+            n
+        };
+        PathspecDiffEntries {
+            range: 0..n,
+            list: self,
+        }
     }
 
     /// Get a matching diff delta by position.
@@ -190,8 +234,7 @@ impl<'ps> PathspecMatchList<'ps> {
     /// always be `None`.
     pub fn diff_entry(&self, i: usize) -> Option<DiffDelta> {
         unsafe {
-            let ptr = raw::git_pathspec_match_list_diff_entry(&*self.raw,
-                                                              i as size_t);
+            let ptr = raw::git_pathspec_match_list_diff_entry(&*self.raw, i as size_t);
             Binding::from_raw_opt(ptr as *mut _)
         }
     }
@@ -199,15 +242,21 @@ impl<'ps> PathspecMatchList<'ps> {
     /// Returns an iterator over the non-matching entries in this list.
     pub fn failed_entries(&self) -> PathspecFailedEntries {
         let n = self.failed_entrycount();
-        let n = if n > 0 && self.failed_entry(0).is_none() {0} else {n};
-        PathspecFailedEntries { range: 0..n, list: self }
+        let n = if n > 0 && self.failed_entry(0).is_none() {
+            0
+        } else {
+            n
+        };
+        PathspecFailedEntries {
+            range: 0..n,
+            list: self,
+        }
     }
 
     /// Get an original pathspec string that had no matches.
     pub fn failed_entry(&self, i: usize) -> Option<&[u8]> {
         unsafe {
-            let ptr = raw::git_pathspec_match_list_failed_entry(&*self.raw,
-                                                                i as size_t);
+            let ptr = raw::git_pathspec_match_list_failed_entry(&*self.raw, i as size_t);
             ::opt_bytes(self, ptr)
         }
     }
@@ -216,11 +265,15 @@ impl<'ps> PathspecMatchList<'ps> {
 impl<'ps> Binding for PathspecMatchList<'ps> {
     type Raw = *mut raw::git_pathspec_match_list;
 
-    unsafe fn from_raw(raw: *mut raw::git_pathspec_match_list)
-                       -> PathspecMatchList<'ps> {
-        PathspecMatchList { raw: raw, _marker: marker::PhantomData }
+    unsafe fn from_raw(raw: *mut raw::git_pathspec_match_list) -> PathspecMatchList<'ps> {
+        PathspecMatchList {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_pathspec_match_list { self.raw }
+    fn raw(&self) -> *mut raw::git_pathspec_match_list {
+        self.raw
+    }
 }
 
 impl<'ps> Drop for PathspecMatchList<'ps> {
@@ -234,7 +287,9 @@ impl<'list> Iterator for PathspecEntries<'list> {
     fn next(&mut self) -> Option<&'list [u8]> {
         self.range.next().and_then(|i| self.list.entry(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'list> DoubleEndedIterator for PathspecEntries<'list> {
     fn next_back(&mut self) -> Option<&'list [u8]> {
@@ -248,7 +303,9 @@ impl<'list> Iterator for PathspecDiffEntries<'list> {
     fn next(&mut self) -> Option<DiffDelta<'list>> {
         self.range.next().and_then(|i| self.list.diff_entry(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'list> DoubleEndedIterator for PathspecDiffEntries<'list> {
     fn next_back(&mut self) -> Option<DiffDelta<'list>> {
@@ -262,11 +319,15 @@ impl<'list> Iterator for PathspecFailedEntries<'list> {
     fn next(&mut self) -> Option<&'list [u8]> {
         self.range.next().and_then(|i| self.list.failed_entry(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'list> DoubleEndedIterator for PathspecFailedEntries<'list> {
     fn next_back(&mut self) -> Option<&'list [u8]> {
-        self.range.next_back().and_then(|i| self.list.failed_entry(i))
+        self.range
+            .next_back()
+            .and_then(|i| self.list.failed_entry(i))
     }
 }
 impl<'list> ExactSizeIterator for PathspecFailedEntries<'list> {}

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::ptr;
 use std::str;
 
-use {raw, Error, Oid, Repository, Object, ObjectType, Blob, Commit, Tree, Tag};
+use {raw, Blob, Commit, Error, Object, ObjectType, Oid, Repository, Tag, Tree};
 use object::CastOrPanic;
 use util::Binding;
 
@@ -39,7 +39,9 @@ impl<'repo> Reference<'repo> {
     }
 
     /// Get access to the underlying raw pointer.
-    pub fn raw(&self) -> *mut raw::git_reference { self.raw }
+    pub fn raw(&self) -> *mut raw::git_reference {
+        self.raw
+    }
 
     /// Delete an existing reference.
     ///
@@ -49,7 +51,9 @@ impl<'repo> Reference<'repo> {
     /// This function will return an error if the reference has changed from the
     /// time it was looked up.
     pub fn delete(&mut self) -> Result<(), Error> {
-        unsafe { try_call!(raw::git_reference_delete(self.raw)); }
+        unsafe {
+            try_call!(raw::git_reference_delete(self.raw));
+        }
         Ok(())
     }
 
@@ -76,7 +80,9 @@ impl<'repo> Reference<'repo> {
     /// Get the full name of a reference.
     ///
     /// Returns `None` if the name is not valid utf-8.
-    pub fn name(&self) -> Option<&str> { str::from_utf8(self.name_bytes()).ok() }
+    pub fn name(&self) -> Option<&str> {
+        str::from_utf8(self.name_bytes()).ok()
+    }
 
     /// Get the full name of a reference.
     pub fn name_bytes(&self) -> &[u8] {
@@ -95,9 +101,7 @@ impl<'repo> Reference<'repo> {
 
     /// Get the full shorthand of a reference.
     pub fn shorthand_bytes(&self) -> &[u8] {
-        unsafe {
-            ::opt_bytes(self, raw::git_reference_shorthand(&*self.raw)).unwrap()
-        }
+        unsafe { ::opt_bytes(self, raw::git_reference_shorthand(&*self.raw)).unwrap() }
     }
 
     /// Get the OID pointed to by a direct reference.
@@ -105,9 +109,7 @@ impl<'repo> Reference<'repo> {
     /// Only available if the reference is direct (i.e. an object id reference,
     /// not a symbolic one).
     pub fn target(&self) -> Option<Oid> {
-        unsafe {
-            Binding::from_raw_opt(raw::git_reference_target(&*self.raw))
-        }
+        unsafe { Binding::from_raw_opt(raw::git_reference_target(&*self.raw)) }
     }
 
     /// Return the peeled OID target of this reference.
@@ -115,9 +117,7 @@ impl<'repo> Reference<'repo> {
     /// This peeled OID only applies to direct references that point to a hard
     /// Tag object: it is the result of peeling such Tag.
     pub fn target_peel(&self) -> Option<Oid> {
-        unsafe {
-            Binding::from_raw_opt(raw::git_reference_target_peel(&*self.raw))
-        }
+        unsafe { Binding::from_raw_opt(raw::git_reference_target_peel(&*self.raw)) }
     }
 
     /// Get full name to the reference pointed to by a symbolic reference.
@@ -125,7 +125,8 @@ impl<'repo> Reference<'repo> {
     /// May return `None` if the reference is either not symbolic or not a
     /// valid utf-8 string.
     pub fn symbolic_target(&self) -> Option<&str> {
-        self.symbolic_target_bytes().and_then(|s| str::from_utf8(s).ok())
+        self.symbolic_target_bytes()
+            .and_then(|s| str::from_utf8(s).ok())
     }
 
     /// Get full name to the reference pointed to by a symbolic reference.
@@ -200,14 +201,23 @@ impl<'repo> Reference<'repo> {
     ///
     /// If the force flag is not enabled, and there's already a reference with
     /// the given name, the renaming will fail.
-    pub fn rename(&mut self, new_name: &str, force: bool,
-                  msg: &str) -> Result<Reference<'repo>, Error> {
+    pub fn rename(
+        &mut self,
+        new_name: &str,
+        force: bool,
+        msg: &str,
+    ) -> Result<Reference<'repo>, Error> {
         let mut raw = ptr::null_mut();
         let new_name = try!(CString::new(new_name));
         let msg = try!(CString::new(msg));
         unsafe {
-            try_call!(raw::git_reference_rename(&mut raw, self.raw, new_name,
-                                                force, msg));
+            try_call!(raw::git_reference_rename(
+                &mut raw,
+                self.raw,
+                new_name,
+                force,
+                msg
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -218,17 +228,19 @@ impl<'repo> Reference<'repo> {
     ///
     /// The new reference will be written to disk, overwriting the given
     /// reference.
-    pub fn set_target(&mut self, id: Oid, reflog_msg: &str)
-                      -> Result<Reference<'repo>, Error> {
+    pub fn set_target(&mut self, id: Oid, reflog_msg: &str) -> Result<Reference<'repo>, Error> {
         let mut raw = ptr::null_mut();
         let msg = try!(CString::new(reflog_msg));
         unsafe {
-            try_call!(raw::git_reference_set_target(&mut raw, self.raw,
-                                                    id.raw(), msg));
+            try_call!(raw::git_reference_set_target(
+                &mut raw,
+                self.raw,
+                id.raw(),
+                msg
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
-
 }
 
 impl<'repo> PartialOrd for Reference<'repo> {
@@ -258,9 +270,14 @@ impl<'repo> Eq for Reference<'repo> {}
 impl<'repo> Binding for Reference<'repo> {
     type Raw = *mut raw::git_reference;
     unsafe fn from_raw(raw: *mut raw::git_reference) -> Reference<'repo> {
-        Reference { raw: raw, _marker: marker::PhantomData }
+        Reference {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_reference { self.raw }
+    fn raw(&self) -> *mut raw::git_reference {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Reference<'repo> {
@@ -284,11 +301,15 @@ impl<'repo> References<'repo> {
 
 impl<'repo> Binding for References<'repo> {
     type Raw = *mut raw::git_reference_iterator;
-    unsafe fn from_raw(raw: *mut raw::git_reference_iterator)
-                       -> References<'repo> {
-        References { raw: raw, _marker: marker::PhantomData }
+    unsafe fn from_raw(raw: *mut raw::git_reference_iterator) -> References<'repo> {
+        References {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_reference_iterator { self.raw }
+    fn raw(&self) -> *mut raw::git_reference_iterator {
+        self.raw
+    }
 }
 
 impl<'repo> Iterator for References<'repo> {
@@ -313,8 +334,7 @@ impl<'repo, 'references> Iterator for ReferenceNames<'repo, 'references> {
     fn next(&mut self) -> Option<Result<&'references str, Error>> {
         let mut out = ptr::null();
         unsafe {
-            try_call_iter!(raw::git_reference_next_name(&mut out,
-                                                        self.inner.raw));
+            try_call_iter!(raw::git_reference_next_name(&mut out, self.inner.raw));
             let bytes = ::opt_bytes(self, out).unwrap();
             let s = str::from_utf8(bytes).unwrap();
             Some(Ok(mem::transmute::<&str, &'references str>(s)))
@@ -324,7 +344,7 @@ impl<'repo, 'references> Iterator for ReferenceNames<'repo, 'references> {
 
 #[cfg(test)]
 mod tests {
-    use {Reference, ObjectType};
+    use {ObjectType, Reference};
 
     #[test]
     fn smoke() {
@@ -345,8 +365,10 @@ mod tests {
         assert_eq!(head.name(), Some("refs/heads/master"));
 
         assert!(head == repo.find_reference("refs/heads/master").unwrap());
-        assert_eq!(repo.refname_to_id("refs/heads/master").unwrap(),
-                   head.target().unwrap());
+        assert_eq!(
+            repo.refname_to_id("refs/heads/master").unwrap(),
+            head.target().unwrap()
+        );
 
         assert!(head.symbolic_target().is_none());
         assert!(head.target_peel().is_none());
@@ -354,9 +376,8 @@ mod tests {
         assert_eq!(head.shorthand(), Some("master"));
         assert!(head.resolve().unwrap() == head);
 
-        let mut tag1 = repo.reference("refs/tags/tag1",
-                                      head.target().unwrap(),
-                                      false, "test").unwrap();
+        let mut tag1 = repo.reference("refs/tags/tag1", head.target().unwrap(), false, "test")
+            .unwrap();
         assert!(tag1.is_tag());
 
         let peeled_commit = tag1.peel(ObjectType::Commit).unwrap();
@@ -365,9 +386,9 @@ mod tests {
 
         tag1.delete().unwrap();
 
-        let mut sym1 = repo.reference_symbolic("refs/tags/tag1",
-                                               "refs/heads/master", false,
-                                               "test").unwrap();
+        let mut sym1 =
+            repo.reference_symbolic("refs/tags/tag1", "refs/heads/master", false, "test")
+                .unwrap();
         sym1.delete().unwrap();
 
         {
@@ -383,6 +404,5 @@ mod tests {
 
         let mut head = head.rename("refs/foo", true, "test").unwrap();
         head.delete().unwrap();
-
     }
 }

--- a/src/reflog.rs
+++ b/src/reflog.rs
@@ -3,7 +3,7 @@ use std::marker;
 use std::str;
 use libc::size_t;
 
-use {raw, signature, Oid, Error, Signature};
+use {raw, signature, Error, Oid, Signature};
 use util::Binding;
 
 /// A reference log of a git repository.
@@ -25,12 +25,20 @@ pub struct ReflogIter<'reflog> {
 
 impl Reflog {
     /// Add a new entry to the in-memory reflog.
-    pub fn append(&mut self, new_oid: Oid, committer: &Signature,
-                  msg: Option<&str>) -> Result<(), Error> {
+    pub fn append(
+        &mut self,
+        new_oid: Oid,
+        committer: &Signature,
+        msg: Option<&str>,
+    ) -> Result<(), Error> {
         let msg = try!(::opt_cstr(msg));
         unsafe {
-            try_call!(raw::git_reflog_append(self.raw, new_oid.raw(),
-                                             committer.raw(), msg));
+            try_call!(raw::git_reflog_append(
+                self.raw,
+                new_oid.raw(),
+                committer.raw(),
+                msg
+            ));
         }
         Ok(())
     }
@@ -41,11 +49,13 @@ impl Reflog {
     /// param value to `true`. When deleting entry n, member old_oid of entry
     /// n-1 (if any) will be updated with the value of member new_oid of entry
     /// n+1.
-    pub fn remove(&mut self, i: usize, rewrite_previous_entry: bool)
-                  -> Result<(), Error> {
+    pub fn remove(&mut self, i: usize, rewrite_previous_entry: bool) -> Result<(), Error> {
         unsafe {
-            try_call!(raw::git_reflog_drop(self.raw, i as size_t,
-                                           rewrite_previous_entry));
+            try_call!(raw::git_reflog_drop(
+                self.raw,
+                i as size_t,
+                rewrite_previous_entry
+            ));
         }
         Ok(())
     }
@@ -73,13 +83,18 @@ impl Reflog {
 
     /// Get an iterator to all entries inside of this reflog
     pub fn iter(&self) -> ReflogIter {
-        ReflogIter { range: 0..self.len(), reflog: self }
+        ReflogIter {
+            range: 0..self.len(),
+            reflog: self,
+        }
     }
 
     /// Write an existing in-memory reflog object back to disk using an atomic
     /// file lock.
     pub fn write(&mut self) -> Result<(), Error> {
-        unsafe { try_call!(raw::git_reflog_write(self.raw)); }
+        unsafe {
+            try_call!(raw::git_reflog_write(self.raw));
+        }
         Ok(())
     }
 }
@@ -90,7 +105,9 @@ impl Binding for Reflog {
     unsafe fn from_raw(raw: *mut raw::git_reflog) -> Reflog {
         Reflog { raw: raw }
     }
-    fn raw(&self) -> *mut raw::git_reflog { self.raw }
+    fn raw(&self) -> *mut raw::git_reflog {
+        self.raw
+    }
 }
 
 impl Drop for Reflog {
@@ -125,9 +142,7 @@ impl<'reflog> ReflogEntry<'reflog> {
 
     /// Get the log message as a byte array.
     pub fn message_bytes(&self) -> Option<&[u8]> {
-        unsafe {
-            ::opt_bytes(self, raw::git_reflog_entry_message(self.raw))
-        }
+        unsafe { ::opt_bytes(self, raw::git_reflog_entry_message(self.raw)) }
     }
 }
 
@@ -135,9 +150,14 @@ impl<'reflog> Binding for ReflogEntry<'reflog> {
     type Raw = *const raw::git_reflog_entry;
 
     unsafe fn from_raw(raw: *const raw::git_reflog_entry) -> ReflogEntry<'reflog> {
-        ReflogEntry { raw: raw, _marker: marker::PhantomData }
+        ReflogEntry {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *const raw::git_reflog_entry { self.raw }
+    fn raw(&self) -> *const raw::git_reflog_entry {
+        self.raw
+    }
 }
 
 impl<'reflog> Iterator for ReflogIter<'reflog> {
@@ -145,7 +165,9 @@ impl<'reflog> Iterator for ReflogIter<'reflog> {
     fn next(&mut self) -> Option<ReflogEntry<'reflog>> {
         self.range.next().and_then(|i| self.reflog.get(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'reflog> DoubleEndedIterator for ReflogIter<'reflog> {
     fn next_back(&mut self) -> Option<ReflogEntry<'reflog>> {

--- a/src/refspec.rs
+++ b/src/refspec.rs
@@ -83,7 +83,12 @@ impl<'remote> Binding for Refspec<'remote> {
     type Raw = *const raw::git_refspec;
 
     unsafe fn from_raw(raw: *const raw::git_refspec) -> Refspec<'remote> {
-        Refspec { raw: raw, _marker: marker::PhantomData }
+        Refspec {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *const raw::git_refspec { self.raw }
+    fn raw(&self) -> *const raw::git_refspec {
+        self.raw
+    }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -174,7 +174,7 @@ impl<'repo> Remote<'repo> {
     }
 
     /// Get the number of refspecs for a remote
-    pub fn refspecs<'a>(&'a self) -> Refspecs<'a> {
+    pub fn refspecs(&self) -> Refspecs {
         let cnt = unsafe { raw::git_remote_refspec_count(&*self.raw) as usize };
         Refspecs { range: 0..cnt, remote: self }
     }
@@ -282,7 +282,7 @@ impl<'repo> Remote<'repo> {
                                 &[RemoteHead]>(slice))
         }
     }
-    
+
     /// Get the remote's list of fetch refspecs
     pub fn fetch_refspecs(&self) -> Result<StringArray, Error> {
         unsafe {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -7,8 +7,8 @@ use std::slice;
 use std::str;
 use libc;
 
-use {raw, Direction, Error, Refspec, Oid, FetchPrune, ProxyOptions};
-use {RemoteCallbacks, Progress, Repository, AutotagOption};
+use {raw, Direction, Error, FetchPrune, Oid, ProxyOptions, Refspec};
+use {AutotagOption, Progress, RemoteCallbacks, Repository};
 use string_array::StringArray;
 use util::Binding;
 
@@ -53,7 +53,10 @@ pub struct PushOptions<'cb> {
 }
 
 /// Holds callbacks for a connection to a `Remote`. Disconnects when dropped
-pub struct RemoteConnection<'repo, 'connection, 'cb> where 'repo: 'connection {
+pub struct RemoteConnection<'repo, 'connection, 'cb>
+where
+    'repo: 'connection,
+{
     _callbacks: Box<RemoteCallbacks<'cb>>,
     _proxy: ProxyOptions<'cb>,
     remote: &'connection mut Remote<'repo>,
@@ -110,10 +113,13 @@ impl<'repo> Remote<'repo> {
     pub fn connect(&mut self, dir: Direction) -> Result<(), Error> {
         // TODO: can callbacks be exposed safely?
         unsafe {
-            try_call!(raw::git_remote_connect(self.raw, dir,
-                                              ptr::null(),
-                                              ptr::null(),
-                                              ptr::null()));
+            try_call!(raw::git_remote_connect(
+                self.raw,
+                dir,
+                ptr::null(),
+                ptr::null(),
+                ptr::null()
+            ));
         }
         Ok(())
     }
@@ -121,19 +127,22 @@ impl<'repo> Remote<'repo> {
     /// Open a connection to a remote with callbacks and proxy settings
     ///
     /// Returns a `RemoteConnection` that will disconnect once dropped
-    pub fn connect_auth<'connection, 'cb>(&'connection mut self,
-                                          dir: Direction,
-                                          cb: Option<RemoteCallbacks<'cb>>,
-                                          proxy_options: Option<ProxyOptions<'cb>>)
-                    -> Result<RemoteConnection<'repo, 'connection, 'cb>, Error> {
-
+    pub fn connect_auth<'connection, 'cb>(
+        &'connection mut self,
+        dir: Direction,
+        cb: Option<RemoteCallbacks<'cb>>,
+        proxy_options: Option<ProxyOptions<'cb>>,
+    ) -> Result<RemoteConnection<'repo, 'connection, 'cb>, Error> {
         let cb = Box::new(cb.unwrap_or_else(RemoteCallbacks::new));
         let proxy_options = proxy_options.unwrap_or_else(ProxyOptions::new);
         unsafe {
-            try_call!(raw::git_remote_connect(self.raw, dir,
-                                              &cb.raw(),
-                                              &proxy_options.raw(),
-                                              ptr::null()));
+            try_call!(raw::git_remote_connect(
+                self.raw,
+                dir,
+                &cb.raw(),
+                &proxy_options.raw(),
+                ptr::null()
+            ));
         }
 
         Ok(RemoteConnection {
@@ -163,8 +172,11 @@ impl<'repo> Remote<'repo> {
     ///
     /// The `specs` argument is a list of refspecs to use for this negotiation
     /// and download. Use an empty array to use the base refspecs.
-    pub fn download(&mut self, specs: &[&str], opts: Option<&mut FetchOptions>)
-                    -> Result<(), Error> {
+    pub fn download(
+        &mut self,
+        specs: &[&str],
+        opts: Option<&mut FetchOptions>,
+    ) -> Result<(), Error> {
         let (_a, _b, arr) = try!(::util::iter2cstrs(specs.iter()));
         let raw = opts.map(|o| o.raw());
         unsafe {
@@ -176,7 +188,10 @@ impl<'repo> Remote<'repo> {
     /// Get the number of refspecs for a remote
     pub fn refspecs(&self) -> Refspecs {
         let cnt = unsafe { raw::git_remote_refspec_count(&*self.raw) as usize };
-        Refspecs { range: 0..cnt, remote: self }
+        Refspecs {
+            range: 0..cnt,
+            remote: self,
+        }
     }
 
     /// Get the `nth` refspec from this remote.
@@ -184,8 +199,7 @@ impl<'repo> Remote<'repo> {
     /// The `refspecs` iterator can be used to iterate over all refspecs.
     pub fn get_refspec(&self, i: usize) -> Option<Refspec<'repo>> {
         unsafe {
-            let ptr = raw::git_remote_get_refspec(&*self.raw,
-                                                  i as libc::size_t);
+            let ptr = raw::git_remote_get_refspec(&*self.raw, i as libc::size_t);
             Binding::from_raw_opt(ptr)
         }
     }
@@ -207,10 +221,12 @@ impl<'repo> Remote<'repo> {
     /// let repo = git2::Repository::discover("rust").unwrap();
     /// fetch_origin_master(repo).unwrap();
     /// ```
-    pub fn fetch(&mut self,
-                 refspecs: &[&str],
-                 opts: Option<&mut FetchOptions>,
-                 reflog_msg: Option<&str>) -> Result<(), Error> {
+    pub fn fetch(
+        &mut self,
+        refspecs: &[&str],
+        opts: Option<&mut FetchOptions>,
+        reflog_msg: Option<&str>,
+    ) -> Result<(), Error> {
         let (_a, _b, arr) = try!(::util::iter2cstrs(refspecs.iter()));
         let msg = try!(::opt_cstr(reflog_msg));
         let raw = opts.map(|o| o.raw());
@@ -221,17 +237,23 @@ impl<'repo> Remote<'repo> {
     }
 
     /// Update the tips to the new state
-    pub fn update_tips(&mut self,
-                       callbacks: Option<&mut RemoteCallbacks>,
-                       update_fetchhead: bool,
-                       download_tags: AutotagOption,
-                       msg: Option<&str>) -> Result<(), Error> {
+    pub fn update_tips(
+        &mut self,
+        callbacks: Option<&mut RemoteCallbacks>,
+        update_fetchhead: bool,
+        download_tags: AutotagOption,
+        msg: Option<&str>,
+    ) -> Result<(), Error> {
         let msg = try!(::opt_cstr(msg));
         let cbs = callbacks.map(|cb| cb.raw());
         unsafe {
-            try_call!(raw::git_remote_update_tips(self.raw, cbs.as_ref(),
-                                                  update_fetchhead,
-                                                  download_tags, msg));
+            try_call!(raw::git_remote_update_tips(
+                self.raw,
+                cbs.as_ref(),
+                update_fetchhead,
+                download_tags,
+                msg
+            ));
         }
         Ok(())
     }
@@ -244,9 +266,7 @@ impl<'repo> Remote<'repo> {
     /// Note that you'll likely want to use `RemoteCallbacks` and set
     /// `push_update_reference` to test whether all the references were pushed
     /// successfully.
-    pub fn push(&mut self,
-                refspecs: &[&str],
-                opts: Option<&mut PushOptions>) -> Result<(), Error> {
+    pub fn push(&mut self, refspecs: &[&str], opts: Option<&mut PushOptions>) -> Result<(), Error> {
         let (_a, _b, arr) = try!(::util::iter2cstrs(refspecs.iter()));
         let raw = opts.map(|o| o.raw());
         unsafe {
@@ -257,9 +277,7 @@ impl<'repo> Remote<'repo> {
 
     /// Get the statistics structure that is filled in by the fetch operation.
     pub fn stats(&self) -> Progress {
-        unsafe {
-            Binding::from_raw(raw::git_remote_stats(self.raw))
-        }
+        unsafe { Binding::from_raw(raw::git_remote_stats(self.raw)) }
     }
 
     /// Get the remote repository's reference advertisement list.
@@ -275,11 +293,15 @@ impl<'repo> Remote<'repo> {
         let mut base = ptr::null_mut();
         unsafe {
             try_call!(raw::git_remote_ls(&mut base, &mut size, self.raw));
-            assert_eq!(mem::size_of::<RemoteHead>(),
-                       mem::size_of::<*const raw::git_remote_head>());
+            assert_eq!(
+                mem::size_of::<RemoteHead>(),
+                mem::size_of::<*const raw::git_remote_head>()
+            );
             let slice = slice::from_raw_parts(base as *const _, size as usize);
-            Ok(mem::transmute::<&[*const raw::git_remote_head],
-                                &[RemoteHead]>(slice))
+            Ok(mem::transmute::<
+                &[*const raw::git_remote_head],
+                &[RemoteHead],
+            >(slice))
         }
     }
 
@@ -323,7 +345,9 @@ impl<'repo> Binding for Remote<'repo> {
             _marker: marker::PhantomData,
         }
     }
-    fn raw(&self) -> *mut raw::git_remote { self.raw }
+    fn raw(&self) -> *mut raw::git_remote {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Remote<'repo> {
@@ -337,11 +361,15 @@ impl<'repo> Iterator for Refspecs<'repo> {
     fn next(&mut self) -> Option<Refspec<'repo>> {
         self.range.next().and_then(|i| self.remote.get_refspec(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'repo> DoubleEndedIterator for Refspecs<'repo> {
     fn next_back(&mut self) -> Option<Refspec<'repo>> {
-        self.range.next_back().and_then(|i| self.remote.get_refspec(i))
+        self.range
+            .next_back()
+            .and_then(|i| self.remote.get_refspec(i))
     }
 }
 impl<'repo> ExactSizeIterator for Refspecs<'repo> {}
@@ -434,10 +462,14 @@ impl<'cb> Binding for FetchOptions<'cb> {
     fn raw(&self) -> raw::git_fetch_options {
         raw::git_fetch_options {
             version: 1,
-            callbacks: self.callbacks.as_ref().map(|m| m.raw())
-                           .unwrap_or_else(|| RemoteCallbacks::new().raw()),
-            proxy_opts: self.proxy.as_ref().map(|m| m.raw())
-                            .unwrap_or_else(|| ProxyOptions::new().raw()),
+            callbacks: self.callbacks
+                .as_ref()
+                .map(|m| m.raw())
+                .unwrap_or_else(|| RemoteCallbacks::new().raw()),
+            proxy_opts: self.proxy
+                .as_ref()
+                .map(|m| m.raw())
+                .unwrap_or_else(|| ProxyOptions::new().raw()),
             prune: ::call::convert(&self.prune),
             update_fetchhead: ::call::convert(&self.update_fetchhead),
             download_tags: ::call::convert(&self.download_tags),
@@ -500,11 +532,14 @@ impl<'cb> Binding for PushOptions<'cb> {
     fn raw(&self) -> raw::git_push_options {
         raw::git_push_options {
             version: 1,
-            callbacks: self.callbacks.as_ref()
-                           .map(|m| m.raw())
-                           .unwrap_or_else(|| RemoteCallbacks::new().raw()),
-            proxy_opts: self.proxy.as_ref().map(|m| m.raw())
-                            .unwrap_or_else(|| ProxyOptions::new().raw()),
+            callbacks: self.callbacks
+                .as_ref()
+                .map(|m| m.raw())
+                .unwrap_or_else(|| RemoteCallbacks::new().raw()),
+            proxy_opts: self.proxy
+                .as_ref()
+                .map(|m| m.raw())
+                .unwrap_or_else(|| ProxyOptions::new().raw()),
             pb_parallelism: self.pb_parallelism as libc::c_uint,
             // TODO: expose this as a builder option
             custom_headers: raw::git_strarray {
@@ -540,7 +575,7 @@ impl<'repo, 'connection, 'cb> Drop for RemoteConnection<'repo, 'connection, 'cb>
 mod tests {
     use std::cell::Cell;
     use tempdir::TempDir;
-    use {Repository, Remote, RemoteCallbacks, Direction, FetchOptions};
+    use {Direction, FetchOptions, Remote, RemoteCallbacks, Repository};
     use {AutotagOption, PushOptions};
 
     #[test]
@@ -572,8 +607,10 @@ mod tests {
         let url = if cfg!(unix) {
             format!("file://{}", remote.display())
         } else {
-            format!("file:///{}", remote.display().to_string()
-                                        .replace("\\", "/"))
+            format!(
+                "file:///{}",
+                remote.display().to_string().replace("\\", "/")
+            )
         };
 
         let mut origin = repo.remote("origin", &url).unwrap();
@@ -622,8 +659,12 @@ mod tests {
 
         origin.fetch(&[], None, None).unwrap();
         origin.fetch(&[], None, Some("foo")).unwrap();
-        origin.update_tips(None, true, AutotagOption::Unspecified, None).unwrap();
-        origin.update_tips(None, true, AutotagOption::All, Some("foo")).unwrap();
+        origin
+            .update_tips(None, true, AutotagOption::Unspecified, None)
+            .unwrap();
+        origin
+            .update_tips(None, true, AutotagOption::All, Some("foo"))
+            .unwrap();
 
         t!(repo.remote_add_fetch("origin", "foo"));
         t!(repo.remote_add_fetch("origin", "bar"));
@@ -669,9 +710,13 @@ mod tests {
                 progress_hit.set(true);
                 true
             });
-            origin.fetch(&[],
-                         Some(FetchOptions::new().remote_callbacks(callbacks)),
-                         None).unwrap();
+            origin
+                .fetch(
+                    &[],
+                    Some(FetchOptions::new().remote_callbacks(callbacks)),
+                    None,
+                )
+                .unwrap();
 
             let list = t!(origin.list());
             assert_eq!(list.len(), 2);
@@ -701,7 +746,9 @@ mod tests {
         let mut origin = repo.remote("origin", &url).unwrap();
 
         {
-            let mut connection = origin.connect_auth(Direction::Fetch, Some(callbacks), None).unwrap();
+            let mut connection = origin
+                .connect_auth(Direction::Fetch, Some(callbacks), None)
+                .unwrap();
             assert!(connection.connected());
 
             let list = t!(connection.list());
@@ -735,7 +782,9 @@ mod tests {
             });
             let mut options = PushOptions::new();
             options.remote_callbacks(callbacks);
-            remote.push(&["refs/heads/master"], Some(&mut options)).unwrap();
+            remote
+                .push(&["refs/heads/master"], Some(&mut options))
+                .unwrap();
         }
         assert!(updated);
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -371,7 +371,7 @@ impl Repository {
     /// List all remotes for a given repository
     pub fn remotes(&self) -> Result<StringArray, Error> {
         let mut arr = raw::git_strarray {
-            strings: 0 as *mut *mut c_char,
+            strings: ptr::null_mut(),
             count: 0,
         };
         unsafe {
@@ -435,7 +435,7 @@ impl Repository {
         let new_name = try!(CString::new(new_name));
         let mut problems = raw::git_strarray {
             count: 0,
-            strings: 0 as *mut *mut c_char,
+            strings: ptr::null_mut(),
         };
         unsafe {
             try_call!(raw::git_remote_rename(&mut problems, self.raw, name,
@@ -929,7 +929,7 @@ impl Repository {
     /// Creates a `AnnotatedCommit` from the given commit id.
     pub fn find_annotated_commit(&self, id: Oid) -> Result<AnnotatedCommit, Error> {
         unsafe {
-            let mut raw = 0 as *mut raw::git_annotated_commit;
+            let mut raw = ptr::null_mut();
             try_call!(raw::git_annotated_commit_lookup(&mut raw, self.raw(), id.raw()));
             Ok(Binding::from_raw(raw))
         }
@@ -1267,7 +1267,7 @@ impl Repository {
     /// An optional fnmatch pattern can also be specified.
     pub fn tag_names(&self, pattern: Option<&str>) -> Result<StringArray, Error> {
         let mut arr = raw::git_strarray {
-            strings: 0 as *mut *mut c_char,
+            strings: ptr::null_mut(),
             count: 0,
         };
         unsafe {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -5,17 +5,19 @@ use std::mem;
 use std::path::Path;
 use std::ptr;
 use std::str;
-use libc::{c_int, c_char, size_t, c_void, c_uint};
+use libc::{c_char, c_int, c_uint, c_void, size_t};
 
-use {raw, Revspec, Error, init, Object, RepositoryOpenFlags, RepositoryState, Remote, Buf, StashFlags};
-use {ResetType, Signature, Reference, References, Submodule, Blame, BlameOptions};
-use {Branches, BranchType, Index, Config, Oid, Blob, BlobWriter, Branch, Commit, Tree};
-use {AnnotatedCommit, MergeOptions, SubmoduleIgnore, SubmoduleStatus, MergeAnalysis, MergePreference};
-use {ObjectType, Tag, Note, Notes, StatusOptions, Statuses, Status, Revwalk};
-use {RevparseMode, RepositoryInitMode, Reflog, IntoCString, Describe};
-use {DescribeOptions, TreeBuilder, Diff, DiffOptions, PackBuilder, Odb};
-use build::{RepoBuilder, CheckoutBuilder};
-use stash::{StashApplyOptions, StashCbData, stash_cb};
+use {init, raw, Buf, Error, Object, Remote, RepositoryOpenFlags, RepositoryState, Revspec,
+     StashFlags};
+use {Blame, BlameOptions, Reference, References, ResetType, Signature, Submodule};
+use {Blob, BlobWriter, Branch, BranchType, Branches, Commit, Config, Index, Oid, Tree};
+use {AnnotatedCommit, MergeAnalysis, MergeOptions, MergePreference, SubmoduleIgnore,
+     SubmoduleStatus};
+use {Note, Notes, ObjectType, Revwalk, Status, StatusOptions, Statuses, Tag};
+use {Describe, IntoCString, Reflog, RepositoryInitMode, RevparseMode};
+use {DescribeOptions, Diff, DiffOptions, Odb, PackBuilder, TreeBuilder};
+use build::{CheckoutBuilder, RepoBuilder};
+use stash::{stash_cb, StashApplyOptions, StashCbData};
 use string_array::StringArray;
 use oid_array::OidArray;
 use util::{self, Binding};
@@ -72,10 +74,12 @@ impl Repository {
         let mut ret = ptr::null_mut();
         let flags = raw::GIT_REPOSITORY_OPEN_FROM_ENV;
         unsafe {
-            try_call!(raw::git_repository_open_ext(&mut ret,
-                                                   ptr::null(),
-                                                   flags as c_uint,
-                                                   ptr::null()));
+            try_call!(raw::git_repository_open_ext(
+                &mut ret,
+                ptr::null(),
+                flags as c_uint,
+                ptr::null()
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -106,11 +110,15 @@ impl Repository {
     /// ceiling_dirs specifies a list of paths that the search through parent
     /// directories will stop before entering.  Use the functions in std::env
     /// to construct or manipulate such a path list.
-    pub fn open_ext<P, O, I>(path: P,
-                             flags: RepositoryOpenFlags,
-                             ceiling_dirs: I)
-                             -> Result<Repository, Error>
-            where P: AsRef<Path>, O: AsRef<OsStr>, I: IntoIterator<Item=O>
+    pub fn open_ext<P, O, I>(
+        path: P,
+        flags: RepositoryOpenFlags,
+        ceiling_dirs: I,
+    ) -> Result<Repository, Error>
+    where
+        P: AsRef<Path>,
+        O: AsRef<OsStr>,
+        I: IntoIterator<Item = O>,
     {
         init();
         let path = try!(path.as_ref().into_c_string());
@@ -118,10 +126,12 @@ impl Repository {
         let ceiling_dirs = try!(ceiling_dirs_os.into_c_string());
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_repository_open_ext(&mut ret,
-                                                   path,
-                                                   flags.bits() as c_uint,
-                                                   ceiling_dirs));
+            try_call!(raw::git_repository_open_ext(
+                &mut ret,
+                path,
+                flags.bits() as c_uint,
+                ceiling_dirs
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -136,8 +146,12 @@ impl Repository {
         let buf = Buf::new();
         let path = try!(path.as_ref().into_c_string());
         unsafe {
-            try_call!(raw::git_repository_discover(buf.raw(), path, 1,
-                                                   ptr::null()));
+            try_call!(raw::git_repository_discover(
+                buf.raw(),
+                path,
+                1,
+                ptr::null()
+            ));
         }
         Repository::open(util::bytes2path(&*buf))
     }
@@ -161,8 +175,10 @@ impl Repository {
     /// Creates a new `--bare` repository in the specified folder.
     ///
     /// The folder must exist prior to invoking this function.
-    pub fn init_opts<P: AsRef<Path>>(path: P, opts: &RepositoryInitOptions)
-                     -> Result<Repository, Error> {
+    pub fn init_opts<P: AsRef<Path>>(
+        path: P,
+        opts: &RepositoryInitOptions,
+    ) -> Result<Repository, Error> {
         init();
         let path = try!(path.as_ref().into_c_string());
         let mut ret = ptr::null_mut();
@@ -177,8 +193,7 @@ impl Repository {
     ///
     /// See the `RepoBuilder` struct for more information. This function will
     /// delegate to a fresh `RepoBuilder`
-    pub fn clone<P: AsRef<Path>>(url: &str, into: P)
-                                 -> Result<Repository, Error> {
+    pub fn clone<P: AsRef<Path>>(url: &str, into: P) -> Result<Repository, Error> {
         ::init();
         RepoBuilder::new().clone(url, into.as_ref())
     }
@@ -187,8 +202,7 @@ impl Repository {
     /// recursively.
     ///
     /// This is similar to `git clone --recursive`.
-    pub fn clone_recurse<P: AsRef<Path>>(url: &str, into: P)
-                                         -> Result<Repository, Error> {
+    pub fn clone_recurse<P: AsRef<Path>>(url: &str, into: P) -> Result<Repository, Error> {
         let repo = Repository::clone(url, into)?;
         repo.update_submodules()?;
         Ok(repo)
@@ -198,9 +212,7 @@ impl Repository {
     ///
     /// Uninitialized submodules will be initialized.
     fn update_submodules(&self) -> Result<(), Error> {
-
-        fn add_subrepos(repo: &Repository, list: &mut Vec<Repository>)
-                        -> Result<(), Error> {
+        fn add_subrepos(repo: &Repository, list: &mut Vec<Repository>) -> Result<(), Error> {
             for mut subm in repo.submodules()? {
                 subm.update(true, None)?;
                 list.push(subm.open()?);
@@ -256,14 +268,17 @@ impl Repository {
     /// In some cases (`@{<-n>}` or `<branchname>@{upstream}`), the expression
     /// may point to an intermediate reference. When such expressions are being
     /// passed in, this intermediate reference is returned.
-    pub fn revparse_ext(&self, spec: &str)
-                        -> Result<(Object, Option<Reference>), Error> {
+    pub fn revparse_ext(&self, spec: &str) -> Result<(Object, Option<Reference>), Error> {
         let spec = try!(CString::new(spec));
         let mut git_obj = ptr::null_mut();
         let mut git_ref = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_revparse_ext(&mut git_obj, &mut git_ref,
-                                            self.raw, spec));
+            try_call!(raw::git_revparse_ext(
+                &mut git_obj,
+                &mut git_ref,
+                self.raw,
+                spec
+            ));
             assert!(!git_obj.is_null());
             Ok((Binding::from_raw(git_obj), Binding::from_raw_opt(git_ref)))
         }
@@ -281,9 +296,7 @@ impl Repository {
 
     /// Tests whether this repository is empty.
     pub fn is_empty(&self) -> Result<bool, Error> {
-        let empty = unsafe {
-            try_call!(raw::git_repository_is_empty(self.raw))
-        };
+        let empty = unsafe { try_call!(raw::git_repository_is_empty(self.raw)) };
         Ok(empty == 1)
     }
 
@@ -343,12 +356,14 @@ impl Repository {
     /// If `update_link` is true, create/update the gitlink file in the workdir
     /// and set config "core.worktree" (if workdir is not the parent of the .git
     /// directory).
-    pub fn set_workdir(&self, path: &Path, update_gitlink: bool)
-                       -> Result<(), Error> {
+    pub fn set_workdir(&self, path: &Path, update_gitlink: bool) -> Result<(), Error> {
         let path = try!(path.into_c_string());
         unsafe {
-            try_call!(raw::git_repository_set_workdir(self.raw(), path,
-                                                      update_gitlink));
+            try_call!(raw::git_repository_set_workdir(
+                self.raw(),
+                path,
+                update_gitlink
+            ));
         }
         Ok(())
     }
@@ -429,8 +444,7 @@ impl Repository {
     /// The returned array of strings is a list of the non-default refspecs
     /// which cannot be renamed and are returned for further processing by the
     /// caller.
-    pub fn remote_rename(&self, name: &str,
-                         new_name: &str) -> Result<StringArray, Error> {
+    pub fn remote_rename(&self, name: &str, new_name: &str) -> Result<StringArray, Error> {
         let name = try!(CString::new(name));
         let new_name = try!(CString::new(new_name));
         let mut problems = raw::git_strarray {
@@ -438,8 +452,12 @@ impl Repository {
             strings: ptr::null_mut(),
         };
         unsafe {
-            try_call!(raw::git_remote_rename(&mut problems, self.raw, name,
-                                             new_name));
+            try_call!(raw::git_remote_rename(
+                &mut problems,
+                self.raw,
+                name,
+                new_name
+            ));
             Ok(Binding::from_raw(problems))
         }
     }
@@ -450,7 +468,9 @@ impl Repository {
     /// will be removed.
     pub fn remote_delete(&self, name: &str) -> Result<(), Error> {
         let name = try!(CString::new(name));
-        unsafe { try_call!(raw::git_remote_delete(self.raw, name)); }
+        unsafe {
+            try_call!(raw::git_remote_delete(self.raw, name));
+        }
         Ok(())
     }
 
@@ -458,8 +478,7 @@ impl Repository {
     ///
     /// Add the given refspec to the fetch list in the configuration. No loaded
     /// remote instances will be affected.
-    pub fn remote_add_fetch(&self, name: &str, spec: &str)
-                            -> Result<(), Error> {
+    pub fn remote_add_fetch(&self, name: &str, spec: &str) -> Result<(), Error> {
         let name = try!(CString::new(name));
         let spec = try!(CString::new(spec));
         unsafe {
@@ -472,8 +491,7 @@ impl Repository {
     ///
     /// Add the given refspec to the push list in the configuration. No
     /// loaded remote instances will be affected.
-    pub fn remote_add_push(&self, name: &str, spec: &str)
-                           -> Result<(), Error> {
+    pub fn remote_add_push(&self, name: &str, spec: &str) -> Result<(), Error> {
         let name = try!(CString::new(name));
         let spec = try!(CString::new(spec));
         unsafe {
@@ -490,7 +508,9 @@ impl Repository {
     pub fn remote_set_url(&self, name: &str, url: &str) -> Result<(), Error> {
         let name = try!(CString::new(name));
         let url = try!(CString::new(url));
-        unsafe { try_call!(raw::git_remote_set_url(self.raw, name, url)); }
+        unsafe {
+            try_call!(raw::git_remote_set_url(self.raw, name, url));
+        }
         Ok(())
     }
 
@@ -501,8 +521,7 @@ impl Repository {
     /// error.
     ///
     /// `None` indicates that it should be cleared.
-    pub fn remote_set_pushurl(&self, name: &str, pushurl: Option<&str>)
-                              -> Result<(), Error> {
+    pub fn remote_set_pushurl(&self, name: &str, pushurl: Option<&str>) -> Result<(), Error> {
         let name = try!(CString::new(name));
         let pushurl = try!(::opt_cstr(pushurl));
         unsafe {
@@ -528,17 +547,21 @@ impl Repository {
     /// to a commit.
     ///
     /// The `checkout` options will only be used for a hard reset.
-    pub fn reset(&self,
-                 target: &Object,
-                 kind: ResetType,
-                 checkout: Option<&mut CheckoutBuilder>)
-                 -> Result<(), Error> {
+    pub fn reset(
+        &self,
+        target: &Object,
+        kind: ResetType,
+        checkout: Option<&mut CheckoutBuilder>,
+    ) -> Result<(), Error> {
         unsafe {
             let mut opts: raw::git_checkout_options = mem::zeroed();
-            try_call!(raw::git_checkout_init_options(&mut opts,
-                                raw::GIT_CHECKOUT_OPTIONS_VERSION));
+            try_call!(raw::git_checkout_init_options(
+                &mut opts,
+                raw::GIT_CHECKOUT_OPTIONS_VERSION
+            ));
             let opts = checkout.map(|c| {
-                c.configure(&mut opts); &mut opts
+                c.configure(&mut opts);
+                &mut opts
             });
             try_call!(raw::git_reset(self.raw, target.raw(), kind, opts));
         }
@@ -552,10 +575,10 @@ impl Repository {
     ///
     /// Passing a `None` target will result in removing entries in the index
     /// matching the provided pathspecs.
-    pub fn reset_default<T, I>(&self,
-                               target: Option<&Object>,
-                               paths: I) -> Result<(), Error>
-        where T: IntoCString, I: IntoIterator<Item=T>,
+    pub fn reset_default<T, I>(&self, target: Option<&Object>, paths: I) -> Result<(), Error>
+    where
+        T: IntoCString,
+        I: IntoIterator<Item = T>,
     {
         let (_a, _b, mut arr) = try!(::util::iter2cstrs(paths));
         let target = target.map(|t| t.raw());
@@ -606,8 +629,10 @@ impl Repository {
     /// to the peeled commit.
     pub fn set_head_detached(&self, commitish: Oid) -> Result<(), Error> {
         unsafe {
-            try_call!(raw::git_repository_set_head_detached(self.raw,
-                                                            commitish.raw()));
+            try_call!(raw::git_repository_set_head_detached(
+                self.raw,
+                commitish.raw()
+            ));
         }
         Ok(())
     }
@@ -627,8 +652,11 @@ impl Repository {
         let mut ret = ptr::null_mut();
         let glob = try!(CString::new(glob));
         unsafe {
-            try_call!(raw::git_reference_iterator_glob_new(&mut ret, self.raw,
-                                                           glob));
+            try_call!(raw::git_reference_iterator_glob_new(
+                &mut ret,
+                self.raw,
+                glob
+            ));
 
             Ok(Binding::from_raw(ret))
         }
@@ -636,7 +664,7 @@ impl Repository {
 
     /// Load all submodules for this repository and return them.
     pub fn submodules(&self) -> Result<Vec<Submodule>, Error> {
-        struct Data<'a, 'b:'a> {
+        struct Data<'a, 'b: 'a> {
             repo: &'b Repository,
             ret: &'a mut Vec<Submodule<'b>>,
         }
@@ -647,21 +675,24 @@ impl Repository {
                 repo: self,
                 ret: &mut ret,
             };
-            try_call!(raw::git_submodule_foreach(self.raw, append,
-                                                 &mut data as *mut _
-                                                           as *mut c_void));
+            try_call!(raw::git_submodule_foreach(
+                self.raw,
+                append,
+                &mut data as *mut _ as *mut c_void
+            ));
         }
 
         return Ok(ret);
 
-        extern fn append(_repo: *mut raw::git_submodule,
-                         name: *const c_char,
-                         data: *mut c_void) -> c_int {
+        extern "C" fn append(
+            _repo: *mut raw::git_submodule,
+            name: *const c_char,
+            data: *mut c_void,
+        ) -> c_int {
             unsafe {
                 let data = &mut *(data as *mut Data);
                 let mut raw = ptr::null_mut();
-                let rc = raw::git_submodule_lookup(&mut raw, data.repo.raw(),
-                                                   name);
+                let rc = raw::git_submodule_lookup(&mut raw, data.repo.raw(), name);
                 assert_eq!(rc, 0);
                 data.ret.push(Binding::from_raw(raw));
             }
@@ -675,13 +706,14 @@ impl Repository {
     /// status, then the results from rename detection (if you enable it) may
     /// not be accurate. To do rename detection properly, this must be called
     /// with no pathspec so that all files can be considered.
-    pub fn statuses(&self, options: Option<&mut StatusOptions>)
-                    -> Result<Statuses, Error> {
+    pub fn statuses(&self, options: Option<&mut StatusOptions>) -> Result<Statuses, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_status_list_new(&mut ret, self.raw,
-                                               options.map(|s| s.raw())
-                                                      .unwrap_or(ptr::null())));
+            try_call!(raw::git_status_list_new(
+                &mut ret,
+                self.raw,
+                options.map(|s| s.raw()).unwrap_or(ptr::null())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -698,8 +730,7 @@ impl Repository {
         let mut ret = 0 as c_int;
         let path = try!(path.into_c_string());
         unsafe {
-            try_call!(raw::git_status_should_ignore(&mut ret, self.raw,
-                                                    path));
+            try_call!(raw::git_status_should_ignore(&mut ret, self.raw, path));
         }
         Ok(ret != 0)
     }
@@ -724,15 +755,13 @@ impl Repository {
         let mut ret = 0 as c_uint;
         let path = try!(path.into_c_string());
         unsafe {
-            try_call!(raw::git_status_file(&mut ret, self.raw,
-                                           path));
+            try_call!(raw::git_status_file(&mut ret, self.raw, path));
         }
         Ok(Status::from_bits_truncate(ret as u32))
     }
 
     /// Create an iterator which loops over the requested branches.
-    pub fn branches(&self, filter: Option<BranchType>)
-                    -> Result<Branches, Error> {
+    pub fn branches(&self, filter: Option<BranchType>) -> Result<Branches, Error> {
         let mut raw = ptr::null_mut();
         unsafe {
             try_call!(raw::git_branch_iterator_new(&mut raw, self.raw(), filter));
@@ -777,12 +806,18 @@ impl Repository {
     /// The Oid returned can in turn be passed to `find_blob` to get a handle to
     /// the blob.
     pub fn blob(&self, data: &[u8]) -> Result<Oid, Error> {
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
             let ptr = data.as_ptr() as *const c_void;
             let len = data.len() as size_t;
-            try_call!(raw::git_blob_create_frombuffer(&mut raw, self.raw(),
-                                                      ptr, len));
+            try_call!(raw::git_blob_create_frombuffer(
+                &mut raw,
+                self.raw(),
+                ptr,
+                len
+            ));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -794,10 +829,11 @@ impl Repository {
     /// the blob.
     pub fn blob_path(&self, path: &Path) -> Result<Oid, Error> {
         let path = try!(path.into_c_string());
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_blob_create_fromdisk(&mut raw, self.raw(),
-                                                    path));
+            try_call!(raw::git_blob_create_fromdisk(&mut raw, self.raw(), path));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -852,30 +888,32 @@ impl Repository {
     /// A new direct reference will be created pointing to this target commit.
     /// If `force` is true and a reference already exists with the given name,
     /// it'll be replaced.
-    pub fn branch(&self,
-                  branch_name: &str,
-                  target: &Commit,
-                  force: bool) -> Result<Branch, Error> {
+    pub fn branch(&self, branch_name: &str, target: &Commit, force: bool) -> Result<Branch, Error> {
         let branch_name = try!(CString::new(branch_name));
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_branch_create(&mut raw,
-                                             self.raw(),
-                                             branch_name,
-                                             target.raw(),
-                                             force));
+            try_call!(raw::git_branch_create(
+                &mut raw,
+                self.raw(),
+                branch_name,
+                target.raw(),
+                force
+            ));
             Ok(Branch::wrap(Binding::from_raw(raw)))
         }
     }
 
     /// Lookup a branch by its name in a repository.
-    pub fn find_branch(&self, name: &str, branch_type: BranchType)
-                       -> Result<Branch, Error> {
+    pub fn find_branch(&self, name: &str, branch_type: BranchType) -> Result<Branch, Error> {
         let name = try!(CString::new(name));
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_branch_lookup(&mut ret, self.raw(), name,
-                                             branch_type));
+            try_call!(raw::git_branch_lookup(
+                &mut ret,
+                self.raw(),
+                name,
+                branch_type
+            ));
             Ok(Branch::wrap(Binding::from_raw(ret)))
         }
     }
@@ -888,30 +926,37 @@ impl Repository {
     /// current branch and make it point to this commit. If the reference
     /// doesn't exist yet, it will be created. If it does exist, the first
     /// parent must be the tip of this branch.
-    pub fn commit(&self,
-                  update_ref: Option<&str>,
-                  author: &Signature,
-                  committer: &Signature,
-                  message: &str,
-                  tree: &Tree,
-                  parents: &[&Commit]) -> Result<Oid, Error> {
+    pub fn commit(
+        &self,
+        update_ref: Option<&str>,
+        author: &Signature,
+        committer: &Signature,
+        message: &str,
+        tree: &Tree,
+        parents: &[&Commit],
+    ) -> Result<Oid, Error> {
         let update_ref = try!(::opt_cstr(update_ref));
-        let mut parent_ptrs = parents.iter().map(|p| {
-            p.raw() as *const raw::git_commit
-        }).collect::<Vec<_>>();
+        let mut parent_ptrs = parents
+            .iter()
+            .map(|p| p.raw() as *const raw::git_commit)
+            .collect::<Vec<_>>();
         let message = try!(CString::new(message));
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_commit_create(&mut raw,
-                                             self.raw(),
-                                             update_ref,
-                                             author.raw(),
-                                             committer.raw(),
-                                             ptr::null(),
-                                             message,
-                                             tree.raw(),
-                                             parents.len() as size_t,
-                                             parent_ptrs.as_mut_ptr()));
+            try_call!(raw::git_commit_create(
+                &mut raw,
+                self.raw(),
+                update_ref,
+                author.raw(),
+                committer.raw(),
+                ptr::null(),
+                message,
+                tree.raw(),
+                parents.len() as size_t,
+                parent_ptrs.as_mut_ptr()
+            ));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -930,18 +975,25 @@ impl Repository {
     pub fn find_annotated_commit(&self, id: Oid) -> Result<AnnotatedCommit, Error> {
         unsafe {
             let mut raw = ptr::null_mut();
-            try_call!(raw::git_annotated_commit_lookup(&mut raw, self.raw(), id.raw()));
+            try_call!(raw::git_annotated_commit_lookup(
+                &mut raw,
+                self.raw(),
+                id.raw()
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
 
     /// Lookup a reference to one of the objects in a repository.
-    pub fn find_object(&self, oid: Oid,
-                       kind: Option<ObjectType>) -> Result<Object, Error> {
+    pub fn find_object(&self, oid: Oid, kind: Option<ObjectType>) -> Result<Object, Error> {
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_object_lookup(&mut raw, self.raw(), oid.raw(),
-                                             kind));
+            try_call!(raw::git_object_lookup(
+                &mut raw,
+                self.raw(),
+                oid.raw(),
+                kind
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -951,15 +1003,25 @@ impl Repository {
     /// This function will return an error if a reference already exists with
     /// the given name unless force is true, in which case it will be
     /// overwritten.
-    pub fn reference(&self, name: &str, id: Oid, force: bool,
-                     log_message: &str) -> Result<Reference, Error> {
+    pub fn reference(
+        &self,
+        name: &str,
+        id: Oid,
+        force: bool,
+        log_message: &str,
+    ) -> Result<Reference, Error> {
         let name = try!(CString::new(name));
         let log_message = try!(CString::new(log_message));
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_reference_create(&mut raw, self.raw(), name,
-                                                id.raw(), force,
-                                                log_message));
+            try_call!(raw::git_reference_create(
+                &mut raw,
+                self.raw(),
+                name,
+                id.raw(),
+                force,
+                log_message
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -994,23 +1056,27 @@ impl Repository {
     /// It will return GIT_EMODIFIED if the reference's value at the time of
     /// updating does not match the one passed through `current_id` (i.e. if the
     /// ref has changed since the user read it).
-    pub fn reference_matching(&self,
-                              name: &str,
-                              id: Oid,
-                              force: bool,
-                              current_id: Oid,
-                              log_message: &str) -> Result<Reference, Error> {
+    pub fn reference_matching(
+        &self,
+        name: &str,
+        id: Oid,
+        force: bool,
+        current_id: Oid,
+        log_message: &str,
+    ) -> Result<Reference, Error> {
         let name = try!(CString::new(name));
         let log_message = try!(CString::new(log_message));
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_reference_create_matching(&mut raw,
-                                                         self.raw(),
-                                                         name,
-                                                         id.raw(),
-                                                         force,
-                                                         current_id.raw(),
-                                                         log_message));
+            try_call!(raw::git_reference_create_matching(
+                &mut raw,
+                self.raw(),
+                name,
+                id.raw(),
+                force,
+                current_id.raw(),
+                log_message
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -1020,18 +1086,26 @@ impl Repository {
     /// This function will return an error if a reference already exists with
     /// the given name unless force is true, in which case it will be
     /// overwritten.
-    pub fn reference_symbolic(&self, name: &str, target: &str,
-                              force: bool,
-                              log_message: &str)
-                              -> Result<Reference, Error> {
+    pub fn reference_symbolic(
+        &self,
+        name: &str,
+        target: &str,
+        force: bool,
+        log_message: &str,
+    ) -> Result<Reference, Error> {
         let name = try!(CString::new(name));
         let target = try!(CString::new(target));
         let log_message = try!(CString::new(log_message));
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_reference_symbolic_create(&mut raw, self.raw(),
-                                                         name, target, force,
-                                                         log_message));
+            try_call!(raw::git_reference_symbolic_create(
+                &mut raw,
+                self.raw(),
+                name,
+                target,
+                force,
+                log_message
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -1045,26 +1119,29 @@ impl Repository {
     /// It will return GIT_EMODIFIED if the reference's value at the time of
     /// updating does not match the one passed through current_value (i.e. if
     /// the ref has changed since the user read it).
-    pub fn reference_symbolic_matching(&self,
-                                       name: &str,
-                                       target: &str,
-                                       force: bool,
-                                       current_value: &str,
-                                       log_message: &str)
-                                       -> Result<Reference, Error> {
+    pub fn reference_symbolic_matching(
+        &self,
+        name: &str,
+        target: &str,
+        force: bool,
+        current_value: &str,
+        log_message: &str,
+    ) -> Result<Reference, Error> {
         let name = try!(CString::new(name));
         let target = try!(CString::new(target));
         let current_value = try!(CString::new(current_value));
         let log_message = try!(CString::new(log_message));
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_reference_symbolic_create_matching(&mut raw,
-                                                                  self.raw(),
-                                                                  name,
-                                                                  target,
-                                                                  force,
-                                                                  current_value,
-                                                                  log_message));
+            try_call!(raw::git_reference_symbolic_create_matching(
+                &mut raw,
+                self.raw(),
+                name,
+                target,
+                force,
+                current_value,
+                log_message
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -1086,7 +1163,9 @@ impl Repository {
     /// allocate or free any `Reference` objects for simple situations.
     pub fn refname_to_id(&self, name: &str) -> Result<Oid, Error> {
         let name = try!(CString::new(name));
-        let mut ret = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut ret = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
             try_call!(raw::git_reference_name_to_id(&mut ret, self.raw(), name));
             Ok(Binding::from_raw(&ret as *const _))
@@ -1094,13 +1173,17 @@ impl Repository {
     }
 
     /// Creates a git_annotated_commit from the given reference.
-    pub fn reference_to_annotated_commit(&self, reference: &Reference)
-                                         -> Result<AnnotatedCommit, Error> {
+    pub fn reference_to_annotated_commit(
+        &self,
+        reference: &Reference,
+    ) -> Result<AnnotatedCommit, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_annotated_commit_from_ref(&mut ret,
-                                                         self.raw(),
-                                                         reference.raw()));
+            try_call!(raw::git_annotated_commit_from_ref(
+                &mut ret,
+                self.raw(),
+                reference.raw()
+            ));
             Ok(AnnotatedCommit::from_raw(ret))
         }
     }
@@ -1131,14 +1214,18 @@ impl Repository {
     /// the submodule repo and perform the clone step as needed. Lastly, call
     /// `add_finalize()` to wrap up adding the new submodule and `.gitmodules`
     /// to the index to be ready to commit.
-    pub fn submodule(&self, url: &str, path: &Path,
-                     use_gitlink: bool) -> Result<Submodule, Error> {
+    pub fn submodule(&self, url: &str, path: &Path, use_gitlink: bool) -> Result<Submodule, Error> {
         let url = try!(CString::new(url));
         let path = try!(path.into_c_string());
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_submodule_add_setup(&mut raw, self.raw(),
-                                                   url, path, use_gitlink));
+            try_call!(raw::git_submodule_add_setup(
+                &mut raw,
+                self.raw(),
+                url,
+                path,
+                use_gitlink
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -1160,13 +1247,15 @@ impl Repository {
     ///
     /// This looks at a submodule and tries to determine the status.  It
     /// will return a combination of the `SubmoduleStatus` values.
-    pub fn submodule_status(&self, name: &str, ignore: SubmoduleIgnore)
-                            -> Result<SubmoduleStatus, Error> {
+    pub fn submodule_status(
+        &self,
+        name: &str,
+        ignore: SubmoduleIgnore,
+    ) -> Result<SubmoduleStatus, Error> {
         let mut ret = 0;
         let name = try!(CString::new(name));
         unsafe {
-            try_call!(raw::git_submodule_status(&mut ret, self.raw, name,
-                                                ignore));
+            try_call!(raw::git_submodule_status(&mut ret, self.raw, name, ignore));
         }
         Ok(SubmoduleStatus::from_bits_truncate(ret as u32))
     }
@@ -1209,16 +1298,29 @@ impl Repository {
     /// The tag name will be checked for validity. You must avoid the characters
     /// '~', '^', ':', ' \ ', '?', '[', and '*', and the sequences ".." and " @
     /// {" which have special meaning to revparse.
-    pub fn tag(&self, name: &str, target: &Object,
-               tagger: &Signature, message: &str,
-               force: bool) -> Result<Oid, Error> {
+    pub fn tag(
+        &self,
+        name: &str,
+        target: &Object,
+        tagger: &Signature,
+        message: &str,
+        force: bool,
+    ) -> Result<Oid, Error> {
         let name = try!(CString::new(name));
         let message = try!(CString::new(message));
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_tag_create(&mut raw, self.raw, name,
-                                          target.raw(), tagger.raw(),
-                                          message, force));
+            try_call!(raw::git_tag_create(
+                &mut raw,
+                self.raw,
+                name,
+                target.raw(),
+                tagger.raw(),
+                message,
+                force
+            ));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -1228,15 +1330,19 @@ impl Repository {
     /// A new direct reference will be created pointing to this target object.
     /// If force is true and a reference already exists with the given name,
     /// it'll be replaced.
-    pub fn tag_lightweight(&self,
-                           name: &str,
-                           target: &Object,
-                           force: bool) -> Result<Oid, Error> {
+    pub fn tag_lightweight(&self, name: &str, target: &Object, force: bool) -> Result<Oid, Error> {
         let name = try!(CString::new(name));
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_tag_create_lightweight(&mut raw, self.raw, name,
-                                                      target.raw(), force));
+            try_call!(raw::git_tag_create_lightweight(
+                &mut raw,
+                self.raw,
+                name,
+                target.raw(),
+                force
+            ));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -1276,7 +1382,9 @@ impl Repository {
                     let s = try!(CString::new(s));
                     try_call!(raw::git_tag_list_match(&mut arr, s, self.raw));
                 }
-                None => { try_call!(raw::git_tag_list(&mut arr, self.raw)); }
+                None => {
+                    try_call!(raw::git_tag_list(&mut arr, self.raw));
+                }
             }
             Ok(Binding::from_raw(arr))
         }
@@ -1284,12 +1392,13 @@ impl Repository {
 
     /// Updates files in the index and the working tree to match the content of
     /// the commit pointed at by HEAD.
-    pub fn checkout_head(&self, opts: Option<&mut CheckoutBuilder>)
-                         -> Result<(), Error> {
+    pub fn checkout_head(&self, opts: Option<&mut CheckoutBuilder>) -> Result<(), Error> {
         unsafe {
             let mut raw_opts = mem::zeroed();
-            try_call!(raw::git_checkout_init_options(&mut raw_opts,
-                                raw::GIT_CHECKOUT_OPTIONS_VERSION));
+            try_call!(raw::git_checkout_init_options(
+                &mut raw_opts,
+                raw::GIT_CHECKOUT_OPTIONS_VERSION
+            ));
             if let Some(c) = opts {
                 c.configure(&mut raw_opts);
             }
@@ -1302,39 +1411,48 @@ impl Repository {
     /// Updates files in the working tree to match the content of the index.
     ///
     /// If the index is `None`, the repository's index will be used.
-    pub fn checkout_index(&self,
-                          index: Option<&mut Index>,
-                          opts: Option<&mut CheckoutBuilder>) -> Result<(), Error> {
+    pub fn checkout_index(
+        &self,
+        index: Option<&mut Index>,
+        opts: Option<&mut CheckoutBuilder>,
+    ) -> Result<(), Error> {
         unsafe {
             let mut raw_opts = mem::zeroed();
-            try_call!(raw::git_checkout_init_options(&mut raw_opts,
-                                raw::GIT_CHECKOUT_OPTIONS_VERSION));
+            try_call!(raw::git_checkout_init_options(
+                &mut raw_opts,
+                raw::GIT_CHECKOUT_OPTIONS_VERSION
+            ));
             if let Some(c) = opts {
                 c.configure(&mut raw_opts);
             }
 
-            try_call!(raw::git_checkout_index(self.raw,
-                                              index.map(|i| &mut *i.raw()),
-                                              &raw_opts));
+            try_call!(raw::git_checkout_index(
+                self.raw,
+                index.map(|i| &mut *i.raw()),
+                &raw_opts
+            ));
         }
         Ok(())
     }
 
     /// Updates files in the index and working tree to match the content of the
     /// tree pointed at by the treeish.
-    pub fn checkout_tree(&self,
-                         treeish: &Object,
-                         opts: Option<&mut CheckoutBuilder>) -> Result<(), Error> {
+    pub fn checkout_tree(
+        &self,
+        treeish: &Object,
+        opts: Option<&mut CheckoutBuilder>,
+    ) -> Result<(), Error> {
         unsafe {
             let mut raw_opts = mem::zeroed();
-            try_call!(raw::git_checkout_init_options(&mut raw_opts,
-                                raw::GIT_CHECKOUT_OPTIONS_VERSION));
+            try_call!(raw::git_checkout_init_options(
+                &mut raw_opts,
+                raw::GIT_CHECKOUT_OPTIONS_VERSION
+            ));
             if let Some(c) = opts {
                 c.configure(&mut raw_opts);
             }
 
-            try_call!(raw::git_checkout_tree(self.raw, &*treeish.raw(),
-                                             &raw_opts));
+            try_call!(raw::git_checkout_tree(self.raw, &*treeish.raw(), &raw_opts));
         }
         Ok(())
     }
@@ -1347,30 +1465,34 @@ impl Repository {
     /// For compatibility with git, the repository is put into a merging state.
     /// Once the commit is done (or if the uses wishes to abort), you should
     /// clear this state by calling git_repository_state_cleanup().
-    pub fn merge(&self,
-                 annotated_commits: &[&AnnotatedCommit],
-                 merge_opts: Option<&mut MergeOptions>,
-                 checkout_opts: Option<&mut CheckoutBuilder>)
-                 -> Result<(), Error>
-    {
+    pub fn merge(
+        &self,
+        annotated_commits: &[&AnnotatedCommit],
+        merge_opts: Option<&mut MergeOptions>,
+        checkout_opts: Option<&mut CheckoutBuilder>,
+    ) -> Result<(), Error> {
         unsafe {
             let mut raw_checkout_opts = mem::zeroed();
-            try_call!(raw::git_checkout_init_options(&mut raw_checkout_opts,
-                                raw::GIT_CHECKOUT_OPTIONS_VERSION));
+            try_call!(raw::git_checkout_init_options(
+                &mut raw_checkout_opts,
+                raw::GIT_CHECKOUT_OPTIONS_VERSION
+            ));
             if let Some(c) = checkout_opts {
                 c.configure(&mut raw_checkout_opts);
             }
 
-            let mut commit_ptrs = annotated_commits.iter().map(|c| {
-                c.raw() as *const raw::git_annotated_commit
-            }).collect::<Vec<_>>();
+            let mut commit_ptrs = annotated_commits
+                .iter()
+                .map(|c| c.raw() as *const raw::git_annotated_commit)
+                .collect::<Vec<_>>();
 
-            try_call!(raw::git_merge(self.raw,
-                                     commit_ptrs.as_mut_ptr(),
-                                     annotated_commits.len() as size_t,
-                                     merge_opts.map(|o| o.raw())
-                                               .unwrap_or(ptr::null()),
-                                     &raw_checkout_opts));
+            try_call!(raw::git_merge(
+                self.raw,
+                commit_ptrs.as_mut_ptr(),
+                annotated_commits.len() as size_t,
+                merge_opts.map(|o| o.raw()).unwrap_or(ptr::null()),
+                &raw_checkout_opts
+            ));
         }
         Ok(())
     }
@@ -1379,14 +1501,21 @@ impl Repository {
     /// the merge. The index may be written as-is to the working directory or
     /// checked out. If the index is to be converted to a tree, the caller
     /// should resolve any conflicts that arose as part of the merge.
-    pub fn merge_commits(&self, our_commit: &Commit, their_commit: &Commit,
-                         opts: Option<&MergeOptions>) -> Result<Index, Error> {
-         let mut raw = ptr::null_mut();
+    pub fn merge_commits(
+        &self,
+        our_commit: &Commit,
+        their_commit: &Commit,
+        opts: Option<&MergeOptions>,
+    ) -> Result<Index, Error> {
+        let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_merge_commits(&mut raw, self.raw,
-                                             our_commit.raw(),
-                                             their_commit.raw(),
-                                             opts.map(|o| o.raw())));
+            try_call!(raw::git_merge_commits(
+                &mut raw,
+                self.raw,
+                our_commit.raw(),
+                their_commit.raw(),
+                opts.map(|o| o.raw())
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -1395,13 +1524,23 @@ impl Repository {
     /// the merge. The index may be written as-is to the working directory or
     /// checked out. If the index is to be converted to a tree, the caller
     /// should resolve any conflicts that arose as part of the merge.
-    pub fn merge_trees(&self, ancestor_tree: &Tree, our_tree: &Tree,
-                       their_tree: &Tree, opts: Option<&MergeOptions>) -> Result<Index, Error> {
+    pub fn merge_trees(
+        &self,
+        ancestor_tree: &Tree,
+        our_tree: &Tree,
+        their_tree: &Tree,
+        opts: Option<&MergeOptions>,
+    ) -> Result<Index, Error> {
         let mut raw = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_merge_trees(&mut raw, self.raw, ancestor_tree.raw(),
-                                           our_tree.raw(), their_tree.raw(),
-                                           opts.map(|o| o.raw())));
+            try_call!(raw::git_merge_trees(
+                &mut raw,
+                self.raw,
+                ancestor_tree.raw(),
+                our_tree.raw(),
+                their_tree.raw(),
+                opts.map(|o| o.raw())
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
@@ -1417,9 +1556,10 @@ impl Repository {
 
     /// Analyzes the given branch(es) and determines the opportunities for
     /// merging them into the HEAD of the repository.
-    pub fn merge_analysis(&self,
-                          their_heads: &[&AnnotatedCommit])
-                          -> Result<(MergeAnalysis, MergePreference), Error> {
+    pub fn merge_analysis(
+        &self,
+        their_heads: &[&AnnotatedCommit],
+    ) -> Result<(MergeAnalysis, MergePreference), Error> {
         unsafe {
             let mut raw_merge_analysis = 0 as raw::git_merge_analysis_t;
             let mut raw_merge_preference = 0 as raw::git_merge_preference_t;
@@ -1427,12 +1567,17 @@ impl Repository {
                 .iter()
                 .map(|v| v.raw() as *const _)
                 .collect::<Vec<_>>();
-            try_call!(raw::git_merge_analysis(&mut raw_merge_analysis,
-                                              &mut raw_merge_preference,
-                                              self.raw,
-                                              their_heads.as_mut_ptr() as *mut _,
-                                              their_heads.len()));
-            Ok((MergeAnalysis::from_bits_truncate(raw_merge_analysis as u32), MergePreference::from_bits_truncate(raw_merge_preference as u32)))
+            try_call!(raw::git_merge_analysis(
+                &mut raw_merge_analysis,
+                &mut raw_merge_preference,
+                self.raw,
+                their_heads.as_mut_ptr() as *mut _,
+                their_heads.len()
+            ));
+            Ok((
+                MergeAnalysis::from_bits_truncate(raw_merge_analysis as u32),
+                MergePreference::from_bits_truncate(raw_merge_preference as u32),
+            ))
         }
     }
 
@@ -1441,25 +1586,31 @@ impl Repository {
     /// The `notes_ref` argument is the canonical name of the reference to use,
     /// defaulting to "refs/notes/commits". If `force` is specified then
     /// previous notes are overwritten.
-    pub fn note(&self,
-                author: &Signature,
-                committer: &Signature,
-                notes_ref: Option<&str>,
-                oid: Oid,
-                note: &str,
-                force: bool) -> Result<Oid, Error> {
+    pub fn note(
+        &self,
+        author: &Signature,
+        committer: &Signature,
+        notes_ref: Option<&str>,
+        oid: Oid,
+        note: &str,
+        force: bool,
+    ) -> Result<Oid, Error> {
         let notes_ref = try!(::opt_cstr(notes_ref));
         let note = try!(CString::new(note));
-        let mut ret = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut ret = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_note_create(&mut ret,
-                                           self.raw,
-                                           notes_ref,
-                                           author.raw(),
-                                           committer.raw(),
-                                           oid.raw(),
-                                           note,
-                                           force));
+            try_call!(raw::git_note_create(
+                &mut ret,
+                self.raw,
+                notes_ref,
+                author.raw(),
+                committer.raw(),
+                oid.raw(),
+                note,
+                force
+            ));
             Ok(Binding::from_raw(&ret as *const _))
         }
     }
@@ -1496,13 +1647,11 @@ impl Repository {
     /// defaulting to "refs/notes/commits".
     ///
     /// The id specified is the Oid of the git object to read the note from.
-    pub fn find_note(&self, notes_ref: Option<&str>, id: Oid)
-                     -> Result<Note, Error> {
+    pub fn find_note(&self, notes_ref: Option<&str>, id: Oid) -> Result<Note, Error> {
         let notes_ref = try!(::opt_cstr(notes_ref));
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_note_read(&mut ret, self.raw, notes_ref,
-                                         id.raw()));
+            try_call!(raw::git_note_read(&mut ret, self.raw, notes_ref, id.raw()));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1513,15 +1662,22 @@ impl Repository {
     /// defaulting to "refs/notes/commits".
     ///
     /// The id specified is the Oid of the git object to remove the note from.
-    pub fn note_delete(&self,
-                       id: Oid,
-                       notes_ref: Option<&str>,
-                       author: &Signature,
-                       committer: &Signature) -> Result<(), Error> {
+    pub fn note_delete(
+        &self,
+        id: Oid,
+        notes_ref: Option<&str>,
+        author: &Signature,
+        committer: &Signature,
+    ) -> Result<(), Error> {
         let notes_ref = try!(::opt_cstr(notes_ref));
         unsafe {
-            try_call!(raw::git_note_remove(self.raw, notes_ref, author.raw(),
-                                           committer.raw(), id.raw()));
+            try_call!(raw::git_note_remove(
+                self.raw,
+                notes_ref,
+                author.raw(),
+                committer.raw(),
+                id.raw()
+            ));
             Ok(())
         }
     }
@@ -1536,26 +1692,33 @@ impl Repository {
     }
 
     /// Get the blame for a single file.
-    pub fn blame_file(&self, path: &Path, opts: Option<&mut BlameOptions>)
-                      -> Result<Blame, Error> {
+    pub fn blame_file(&self, path: &Path, opts: Option<&mut BlameOptions>) -> Result<Blame, Error> {
         let path = try!(path.into_c_string());
         let mut raw = ptr::null_mut();
 
         unsafe {
-            try_call!(raw::git_blame_file(&mut raw,
-                                          self.raw(),
-                                          path,
-                                          opts.map(|s| s.raw())));
+            try_call!(raw::git_blame_file(
+                &mut raw,
+                self.raw(),
+                path,
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(raw))
         }
     }
 
     /// Find a merge base between two commits
     pub fn merge_base(&self, one: Oid, two: Oid) -> Result<Oid, Error> {
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
-            try_call!(raw::git_merge_base(&mut raw, self.raw,
-                                          one.raw(), two.raw()));
+            try_call!(raw::git_merge_base(
+                &mut raw,
+                self.raw,
+                one.raw(),
+                two.raw()
+            ));
             Ok(Binding::from_raw(&raw as *const _))
         }
     }
@@ -1567,8 +1730,12 @@ impl Repository {
             count: 0,
         };
         unsafe {
-            try_call!(raw::git_merge_bases(&mut arr, self.raw,
-                                          one.raw(), two.raw()));
+            try_call!(raw::git_merge_bases(
+                &mut arr,
+                self.raw,
+                one.raw(),
+                two.raw()
+            ));
             Ok(Binding::from_raw(arr))
         }
     }
@@ -1580,25 +1747,29 @@ impl Repository {
     /// upstream relationship, but it helps to think of one as a branch and the
     /// other as its upstream, the ahead and behind values will be what git
     /// would report for the branches.
-    pub fn graph_ahead_behind(&self, local: Oid, upstream: Oid)
-                              -> Result<(usize, usize), Error> {
+    pub fn graph_ahead_behind(&self, local: Oid, upstream: Oid) -> Result<(usize, usize), Error> {
         unsafe {
             let mut ahead: size_t = 0;
             let mut behind: size_t = 0;
-            try_call!(raw::git_graph_ahead_behind(&mut ahead, &mut behind,
-                                                  self.raw(), local.raw(),
-                                                  upstream.raw()));
+            try_call!(raw::git_graph_ahead_behind(
+                &mut ahead,
+                &mut behind,
+                self.raw(),
+                local.raw(),
+                upstream.raw()
+            ));
             Ok((ahead as usize, behind as usize))
         }
     }
 
     /// Determine if a commit is the descendant of another commit
-    pub fn graph_descendant_of(&self, commit: Oid, ancestor: Oid)
-                               -> Result<bool, Error> {
+    pub fn graph_descendant_of(&self, commit: Oid, ancestor: Oid) -> Result<bool, Error> {
         unsafe {
-            let rv = try_call!(raw::git_graph_descendant_of(self.raw(),
-                                                            commit.raw(),
-                                                            ancestor.raw()));
+            let rv = try_call!(raw::git_graph_descendant_of(
+                self.raw(),
+                commit.raw(),
+                ancestor.raw()
+            ));
             Ok(rv != 0)
         }
     }
@@ -1619,15 +1790,16 @@ impl Repository {
     /// Delete the reflog for the given reference
     pub fn reflog_delete(&self, name: &str) -> Result<(), Error> {
         let name = try!(CString::new(name));
-        unsafe { try_call!(raw::git_reflog_delete(self.raw, name)); }
+        unsafe {
+            try_call!(raw::git_reflog_delete(self.raw, name));
+        }
         Ok(())
     }
 
     /// Rename a reflog
     ///
     /// The reflog to be renamed is expected to already exist.
-    pub fn reflog_rename(&self, old_name: &str, new_name: &str)
-                         -> Result<(), Error> {
+    pub fn reflog_rename(&self, old_name: &str, new_name: &str) -> Result<(), Error> {
         let old_name = try!(CString::new(old_name));
         let new_name = try!(CString::new(new_name));
         unsafe {
@@ -1639,9 +1811,7 @@ impl Repository {
     /// Check if the given reference has a reflog.
     pub fn reference_has_log(&self, name: &str) -> Result<bool, Error> {
         let name = try!(CString::new(name));
-        let ret = unsafe {
-            try_call!(raw::git_reference_has_log(self.raw, name))
-        };
+        let ret = unsafe { try_call!(raw::git_reference_has_log(self.raw, name)) };
         Ok(ret != 0)
     }
 
@@ -1675,18 +1845,21 @@ impl Repository {
     /// second tree will be used for the "new_file" side of the delta.  You can
     /// pass `None` to indicate an empty tree, although it is an error to pass
     /// `None` for both the `old_tree` and `new_tree`.
-    pub fn diff_tree_to_tree(&self,
-                             old_tree: Option<&Tree>,
-                             new_tree: Option<&Tree>,
-                             opts: Option<&mut DiffOptions>)
-                             -> Result<Diff, Error> {
+    pub fn diff_tree_to_tree(
+        &self,
+        old_tree: Option<&Tree>,
+        new_tree: Option<&Tree>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Diff, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_diff_tree_to_tree(&mut ret,
-                                                 self.raw(),
-                                                 old_tree.map(|s| s.raw()),
-                                                 new_tree.map(|s| s.raw()),
-                                                 opts.map(|s| s.raw())));
+            try_call!(raw::git_diff_tree_to_tree(
+                &mut ret,
+                self.raw(),
+                old_tree.map(|s| s.raw()),
+                new_tree.map(|s| s.raw()),
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1704,18 +1877,21 @@ impl Repository {
     /// (if it has changed) before the diff is generated.
     ///
     /// If the tree is `None`, then it is considered an empty tree.
-    pub fn diff_tree_to_index(&self,
-                              old_tree: Option<&Tree>,
-                              index: Option<&Index>,
-                              opts: Option<&mut DiffOptions>)
-                              -> Result<Diff, Error> {
+    pub fn diff_tree_to_index(
+        &self,
+        old_tree: Option<&Tree>,
+        index: Option<&Index>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Diff, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_diff_tree_to_index(&mut ret,
-                                                  self.raw(),
-                                                  old_tree.map(|s| s.raw()),
-                                                  index.map(|s| s.raw()),
-                                                  opts.map(|s| s.raw())));
+            try_call!(raw::git_diff_tree_to_index(
+                &mut ret,
+                self.raw(),
+                old_tree.map(|s| s.raw()),
+                index.map(|s| s.raw()),
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1724,18 +1900,21 @@ impl Repository {
     ///
     /// The first index will be used for the "old_file" side of the delta, and
     /// the second index will be used for the "new_file" side of the delta.
-    pub fn diff_index_to_index(&self,
-                               old_index: &Index,
-                               new_index: &Index,
-                               opts: Option<&mut DiffOptions>)
-                               -> Result<Diff, Error> {
+    pub fn diff_index_to_index(
+        &self,
+        old_index: &Index,
+        new_index: &Index,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Diff, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_diff_index_to_index(&mut ret,
-                                                   self.raw(),
-                                                   old_index.raw(),
-                                                   new_index.raw(),
-                                                   opts.map(|s| s.raw())));
+            try_call!(raw::git_diff_index_to_index(
+                &mut ret,
+                self.raw(),
+                old_index.raw(),
+                new_index.raw(),
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1753,16 +1932,19 @@ impl Repository {
     /// If you pass `None` for the index, then the existing index of the `repo`
     /// will be used.  In this case, the index will be refreshed from disk
     /// (if it has changed) before the diff is generated.
-    pub fn diff_index_to_workdir(&self,
-                                 index: Option<&Index>,
-                                 opts: Option<&mut DiffOptions>)
-                                 -> Result<Diff, Error> {
+    pub fn diff_index_to_workdir(
+        &self,
+        index: Option<&Index>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Diff, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_diff_index_to_workdir(&mut ret,
-                                                     self.raw(),
-                                                     index.map(|s| s.raw()),
-                                                     opts.map(|s| s.raw())));
+            try_call!(raw::git_diff_index_to_workdir(
+                &mut ret,
+                self.raw(),
+                index.map(|s| s.raw()),
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1785,16 +1967,19 @@ impl Repository {
     /// show status 'deleted' since there is a staged delete.
     ///
     /// If `None` is passed for `tree`, then an empty tree is used.
-    pub fn diff_tree_to_workdir(&self,
-                                old_tree: Option<&Tree>,
-                                opts: Option<&mut DiffOptions>)
-                                -> Result<Diff, Error> {
+    pub fn diff_tree_to_workdir(
+        &self,
+        old_tree: Option<&Tree>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Diff, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_diff_tree_to_workdir(&mut ret,
-                                                    self.raw(),
-                                                    old_tree.map(|s| s.raw()),
-                                                    opts.map(|s| s.raw())));
+            try_call!(raw::git_diff_tree_to_workdir(
+                &mut ret,
+                self.raw(),
+                old_tree.map(|s| s.raw()),
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1805,14 +1990,19 @@ impl Repository {
     /// This emulates `git diff <tree>` by diffing the tree to the index and
     /// the index to the working directory and blending the results into a
     /// single diff that includes staged deleted, etc.
-    pub fn diff_tree_to_workdir_with_index(&self,
-                                           old_tree: Option<&Tree>,
-                                           opts: Option<&mut DiffOptions>)
-                                           -> Result<Diff, Error> {
+    pub fn diff_tree_to_workdir_with_index(
+        &self,
+        old_tree: Option<&Tree>,
+        opts: Option<&mut DiffOptions>,
+    ) -> Result<Diff, Error> {
         let mut ret = ptr::null_mut();
         unsafe {
-            try_call!(raw::git_diff_tree_to_workdir_with_index(&mut ret,
-                    self.raw(), old_tree.map(|s| s.raw()), opts.map(|s| s.raw())));
+            try_call!(raw::git_diff_tree_to_workdir_with_index(
+                &mut ret,
+                self.raw(),
+                old_tree.map(|s| s.raw()),
+                opts.map(|s| s.raw())
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -1827,29 +2017,35 @@ impl Repository {
     }
 
     /// Save the local modifications to a new stash.
-    pub fn stash_save(&mut self,
-                      stasher: &Signature,
-                      message: &str,
-                      flags: Option<StashFlags>)
-                      -> Result<Oid, Error> {
+    pub fn stash_save(
+        &mut self,
+        stasher: &Signature,
+        message: &str,
+        flags: Option<StashFlags>,
+    ) -> Result<Oid, Error> {
         unsafe {
-            let mut raw_oid = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+            let mut raw_oid = raw::git_oid {
+                id: [0; raw::GIT_OID_RAWSZ],
+            };
             let message = try!(CString::new(message));
             let flags = flags.unwrap_or_else(StashFlags::empty);
-            try_call!(raw::git_stash_save(&mut raw_oid,
-                                          self.raw(),
-                                          stasher.raw(),
-                                          message,
-                                          flags.bits() as c_uint));
+            try_call!(raw::git_stash_save(
+                &mut raw_oid,
+                self.raw(),
+                stasher.raw(),
+                message,
+                flags.bits() as c_uint
+            ));
             Ok(Binding::from_raw(&raw_oid as *const _))
         }
     }
 
     /// Apply a single stashed state from the stash list.
-    pub fn stash_apply(&mut self,
-                       index: usize,
-                       opts: Option<&mut StashApplyOptions>)
-                       -> Result<(), Error> {
+    pub fn stash_apply(
+        &mut self,
+        index: usize,
+        opts: Option<&mut StashApplyOptions>,
+    ) -> Result<(), Error> {
         unsafe {
             let opts = opts.map(|opts| opts.raw());
             try_call!(raw::git_stash_apply(self.raw(), index, opts));
@@ -1861,13 +2057,18 @@ impl Repository {
     ///
     /// Return `true` to continue iterating or `false` to stop.
     pub fn stash_foreach<C>(&mut self, mut callback: C) -> Result<(), Error>
-        where C: FnMut(usize, &str, &Oid) -> bool
+    where
+        C: FnMut(usize, &str, &Oid) -> bool,
     {
         unsafe {
-            let mut data = StashCbData { callback: &mut callback };
-            try_call!(raw::git_stash_foreach(self.raw(),
-                                             stash_cb,
-                                             &mut data as *mut _ as *mut _));
+            let mut data = StashCbData {
+                callback: &mut callback,
+            };
+            try_call!(raw::git_stash_foreach(
+                self.raw(),
+                stash_cb,
+                &mut data as *mut _ as *mut _
+            ));
             Ok(())
         }
     }
@@ -1881,10 +2082,11 @@ impl Repository {
     }
 
     /// Apply a single stashed state from the stash list and remove it from the list if successful.
-    pub fn stash_pop(&mut self,
-                     index: usize,
-                     opts: Option<&mut StashApplyOptions>)
-                     -> Result<(), Error> {
+    pub fn stash_pop(
+        &mut self,
+        index: usize,
+        opts: Option<&mut StashApplyOptions>,
+    ) -> Result<(), Error> {
         unsafe {
             let opts = opts.map(|opts| opts.raw());
             try_call!(raw::git_stash_pop(self.raw(), index, opts));
@@ -1898,7 +2100,9 @@ impl Binding for Repository {
     unsafe fn from_raw(ptr: *mut raw::git_repository) -> Repository {
         Repository { raw: ptr }
     }
-    fn raw(&self) -> *mut raw::git_repository { self.raw }
+    fn raw(&self) -> *mut raw::git_repository {
+        self.raw
+    }
 }
 
 impl Drop for Repository {
@@ -1914,9 +2118,8 @@ impl RepositoryInitOptions {
     /// and initializing a directory from the user-configured templates path.
     pub fn new() -> RepositoryInitOptions {
         RepositoryInitOptions {
-            flags: raw::GIT_REPOSITORY_INIT_MKDIR as u32 |
-                   raw::GIT_REPOSITORY_INIT_MKPATH as u32 |
-                   raw::GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE as u32,
+            flags: raw::GIT_REPOSITORY_INIT_MKDIR as u32 | raw::GIT_REPOSITORY_INIT_MKPATH as u32
+                | raw::GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE as u32,
             mode: 0,
             workdir_path: None,
             description: None,
@@ -1967,8 +2170,7 @@ impl RepositoryInitOptions {
     }
 
     /// Set to one of the `RepositoryInit` constants, or a custom value.
-    pub fn mode(&mut self, mode: RepositoryInitMode)
-                -> &mut RepositoryInitOptions {
+    pub fn mode(&mut self, mode: RepositoryInitMode) -> &mut RepositoryInitOptions {
         self.mode = mode.bits();
         self
     }
@@ -1980,13 +2182,15 @@ impl RepositoryInitOptions {
     /// `/usr/share/git-core-templates` will be used (if it exists).
     ///
     /// Defaults to true.
-    pub fn external_template(&mut self, enabled: bool)
-                             -> &mut RepositoryInitOptions {
+    pub fn external_template(&mut self, enabled: bool) -> &mut RepositoryInitOptions {
         self.flag(raw::GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE, enabled)
     }
 
-    fn flag(&mut self, flag: raw::git_repository_init_flag_t, on: bool)
-            -> &mut RepositoryInitOptions {
+    fn flag(
+        &mut self,
+        flag: raw::git_repository_init_flag_t,
+        on: bool,
+    ) -> &mut RepositoryInitOptions {
         if on {
             self.flags |= flag as u32;
         } else {
@@ -2046,8 +2250,13 @@ impl RepositoryInitOptions {
     /// interior of this structure.
     pub unsafe fn raw(&self) -> raw::git_repository_init_options {
         let mut opts = mem::zeroed();
-        assert_eq!(raw::git_repository_init_init_options(&mut opts,
-                                raw::GIT_REPOSITORY_INIT_OPTIONS_VERSION), 0);
+        assert_eq!(
+            raw::git_repository_init_init_options(
+                &mut opts,
+                raw::GIT_REPOSITORY_INIT_OPTIONS_VERSION
+            ),
+            0
+        );
         opts.flags = self.flags;
         opts.mode = self.mode;
         opts.workdir_path = ::call::convert(&self.workdir_path);
@@ -2065,7 +2274,7 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use tempdir::TempDir;
-    use {Repository, Oid, ObjectType, ResetType};
+    use {ObjectType, Oid, Repository, ResetType};
     use build::CheckoutBuilder;
 
     #[test]
@@ -2096,8 +2305,10 @@ mod tests {
         assert!(!repo.is_bare());
         assert!(!repo.is_shallow());
         assert!(repo.is_empty().unwrap());
-        assert_eq!(::test::realpath(&repo.path()).unwrap(),
-                   ::test::realpath(&td.path().join(".git/")).unwrap());
+        assert_eq!(
+            ::test::realpath(&repo.path()).unwrap(),
+            ::test::realpath(&td.path().join(".git/")).unwrap()
+        );
         assert_eq!(repo.state(), ::RepositoryState::Clean);
     }
 
@@ -2109,8 +2320,10 @@ mod tests {
 
         let repo = Repository::open(path).unwrap();
         assert!(repo.is_bare());
-        assert_eq!(::test::realpath(&repo.path()).unwrap(),
-                   ::test::realpath(&td.path().join("")).unwrap());
+        assert_eq!(
+            ::test::realpath(&repo.path()).unwrap(),
+            ::test::realpath(&td.path().join("")).unwrap()
+        );
     }
 
     #[test]
@@ -2149,8 +2362,10 @@ mod tests {
         fs::create_dir(&subdir).unwrap();
         Repository::init_bare(td.path()).unwrap();
         let repo = Repository::discover(&subdir).unwrap();
-        assert_eq!(::test::realpath(&repo.path()).unwrap(),
-                   ::test::realpath(&td.path().join("")).unwrap());
+        assert_eq!(
+            ::test::realpath(&repo.path()).unwrap(),
+            ::test::realpath(&td.path().join("")).unwrap()
+        );
     }
 
     #[test]
@@ -2160,22 +2375,27 @@ mod tests {
         fs::create_dir(&subdir).unwrap();
         Repository::init(td.path()).unwrap();
 
-        let repo = Repository::open_ext(&subdir, ::RepositoryOpenFlags::empty(), &[] as &[&OsStr]).unwrap();
+        let repo = Repository::open_ext(&subdir, ::RepositoryOpenFlags::empty(), &[] as &[&OsStr])
+            .unwrap();
         assert!(!repo.is_bare());
-        assert_eq!(::test::realpath(&repo.path()).unwrap(),
-                   ::test::realpath(&td.path().join(".git")).unwrap());
+        assert_eq!(
+            ::test::realpath(&repo.path()).unwrap(),
+            ::test::realpath(&td.path().join(".git")).unwrap()
+        );
 
         let repo = Repository::open_ext(&subdir, ::REPOSITORY_OPEN_BARE, &[] as &[&OsStr]).unwrap();
         assert!(repo.is_bare());
-        assert_eq!(::test::realpath(&repo.path()).unwrap(),
-                   ::test::realpath(&td.path().join(".git")).unwrap());
+        assert_eq!(
+            ::test::realpath(&repo.path()).unwrap(),
+            ::test::realpath(&td.path().join(".git")).unwrap()
+        );
 
-        let err = Repository::open_ext(&subdir, ::REPOSITORY_OPEN_NO_SEARCH, &[] as &[&OsStr]).err().unwrap();
+        let err = Repository::open_ext(&subdir, ::REPOSITORY_OPEN_NO_SEARCH, &[] as &[&OsStr])
+            .err()
+            .unwrap();
         assert_eq!(err.code(), ::ErrorCode::NotFound);
 
-        assert!(Repository::open_ext(&subdir,
-                                     ::RepositoryOpenFlags::empty(),
-                                     &[&subdir]).is_ok());
+        assert!(Repository::open_ext(&subdir, ::RepositoryOpenFlags::empty(), &[&subdir]).is_ok());
     }
 
     fn graph_repo_init() -> (TempDir, Repository) {
@@ -2189,8 +2409,8 @@ mod tests {
 
             let tree = repo.find_tree(id).unwrap();
             let sig = repo.signature().unwrap();
-            repo.commit(Some("HEAD"), &sig, &sig, "second",
-                        &tree, &[&head]).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "second", &tree, &[&head])
+                .unwrap();
         }
         (_td, repo)
     }
@@ -2202,12 +2422,10 @@ mod tests {
         let head = repo.find_commit(head).unwrap();
         let head_id = head.id();
         let head_parent_id = head.parent(0).unwrap().id();
-        let (ahead, behind) = repo.graph_ahead_behind(head_id,
-                                                      head_parent_id).unwrap();
+        let (ahead, behind) = repo.graph_ahead_behind(head_id, head_parent_id).unwrap();
         assert_eq!(ahead, 1);
         assert_eq!(behind, 0);
-        let (ahead, behind) = repo.graph_ahead_behind(head_parent_id,
-                                                      head_id).unwrap();
+        let (ahead, behind) = repo.graph_ahead_behind(head_parent_id, head_id).unwrap();
         assert_eq!(ahead, 0);
         assert_eq!(behind, 1);
     }
@@ -2231,7 +2449,10 @@ mod tests {
         assert_eq!(repo.reference_has_log("refs/heads/master").unwrap(), true);
         assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), false);
         let master_oid = repo.revparse_single("master").unwrap().id();
-        assert!(repo.reference("NOT_HEAD", master_oid, false, "creating a new branch").is_ok());
+        assert!(
+            repo.reference("NOT_HEAD", master_oid, false, "creating a new branch")
+                .is_ok()
+        );
         assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), false);
         assert!(repo.reference_ensure_log("NOT_HEAD").is_ok());
         assert_eq!(repo.reference_has_log("NOT_HEAD").unwrap(), true);
@@ -2288,8 +2509,14 @@ mod tests {
         index.add_path(Path::new("file_a")).unwrap();
         let id_a = index.write_tree().unwrap();
         let tree_a = repo.find_tree(id_a).unwrap();
-        let oid2 = repo.commit(Some("refs/heads/branch_a"), &sig, &sig,
-                               "commit 2", &tree_a, &[&commit1]).unwrap();
+        let oid2 = repo.commit(
+            Some("refs/heads/branch_a"),
+            &sig,
+            &sig,
+            "commit 2",
+            &tree_a,
+            &[&commit1],
+        ).unwrap();
         let commit2 = repo.find_commit(oid2).unwrap();
         println!("created oid2 {:?}", oid2);
 
@@ -2302,8 +2529,14 @@ mod tests {
         index.add_path(Path::new("file_b")).unwrap();
         let id_b = index.write_tree().unwrap();
         let tree_b = repo.find_tree(id_b).unwrap();
-        let oid3 = repo.commit(Some("refs/heads/branch_b"), &sig, &sig,
-                               "commit 3", &tree_b, &[&commit1]).unwrap();
+        let oid3 = repo.commit(
+            Some("refs/heads/branch_b"),
+            &sig,
+            &sig,
+            "commit 3",
+            &tree_b,
+            &[&commit1],
+        ).unwrap();
         let commit3 = repo.find_commit(oid3).unwrap();
         println!("created oid3 {:?}", oid3);
 
@@ -2311,9 +2544,14 @@ mod tests {
         //let mut index4 = repo.merge_commits(&commit2, &commit3, None).unwrap();
         repo.set_head("refs/heads/branch_a").unwrap();
         repo.checkout_head(None).unwrap();
-        let oid4 = repo.commit(Some("refs/heads/branch_a"), &sig, &sig,
-                               "commit 4", &tree_a,
-                               &[&commit2, &commit3]).unwrap();
+        let oid4 = repo.commit(
+            Some("refs/heads/branch_a"),
+            &sig,
+            &sig,
+            "commit 4",
+            &tree_a,
+            &[&commit2, &commit3],
+        ).unwrap();
         //index4.write_tree_to(&repo).unwrap();
         println!("created oid4 {:?}", oid4);
 
@@ -2321,9 +2559,14 @@ mod tests {
         //let mut index5 = repo.merge_commits(&commit3, &commit2, None).unwrap();
         repo.set_head("refs/heads/branch_b").unwrap();
         repo.checkout_head(None).unwrap();
-        let oid5 = repo.commit(Some("refs/heads/branch_b"), &sig, &sig,
-                               "commit 5", &tree_a,
-                               &[&commit3, &commit2]).unwrap();
+        let oid5 = repo.commit(
+            Some("refs/heads/branch_b"),
+            &sig,
+            &sig,
+            "commit 5",
+            &tree_a,
+            &[&commit3, &commit2],
+        ).unwrap();
         //index5.write_tree_to(&repo).unwrap();
         println!("created oid5 {:?}", oid5);
 
@@ -2343,7 +2586,7 @@ mod tests {
         }
         assert!(found_oid2);
         assert!(found_oid3);
-	    assert_eq!(merge_bases.len(), 2);
+        assert_eq!(merge_bases.len(), 2);
     }
 
     #[test]

--- a/src/revspec.rs
+++ b/src/revspec.rs
@@ -9,18 +9,30 @@ pub struct Revspec<'repo> {
 
 impl<'repo> Revspec<'repo> {
     /// Assembles a new revspec from the from/to components.
-    pub fn from_objects(from: Option<Object<'repo>>,
-                        to: Option<Object<'repo>>,
-                        mode: RevparseMode) -> Revspec<'repo> {
-        Revspec { from: from, to: to, mode: mode }
+    pub fn from_objects(
+        from: Option<Object<'repo>>,
+        to: Option<Object<'repo>>,
+        mode: RevparseMode,
+    ) -> Revspec<'repo> {
+        Revspec {
+            from: from,
+            to: to,
+            mode: mode,
+        }
     }
 
     /// Access the `from` range of this revspec.
-    pub fn from(&self) -> Option<&Object<'repo>> { self.from.as_ref() }
+    pub fn from(&self) -> Option<&Object<'repo>> {
+        self.from.as_ref()
+    }
 
     /// Access the `to` range of this revspec.
-    pub fn to(&self) -> Option<&Object<'repo>> { self.to.as_ref() }
+    pub fn to(&self) -> Option<&Object<'repo>> {
+        self.to.as_ref()
+    }
 
     /// Returns the intent of the revspec.
-    pub fn mode(&self) -> RevparseMode { self.mode }
+    pub fn mode(&self) -> RevparseMode {
+        self.mode
+    }
 }

--- a/src/revwalk.rs
+++ b/src/revwalk.rs
@@ -2,7 +2,7 @@ use std::marker;
 use std::ffi::CString;
 use libc::c_uint;
 
-use {raw, Error, Sort, Oid, Repository};
+use {raw, Error, Oid, Repository, Sort};
 use util::Binding;
 
 /// A revwalk allows traversal of the commit graph defined by including one or
@@ -23,9 +23,7 @@ impl<'repo> Revwalk<'repo> {
 
     /// Set the order in which commits are visited.
     pub fn set_sorting(&mut self, sort_mode: Sort) {
-        unsafe {
-            raw::git_revwalk_sorting(self.raw(), sort_mode.bits() as c_uint)
-        }
+        unsafe { raw::git_revwalk_sorting(self.raw(), sort_mode.bits() as c_uint) }
     }
 
     /// Simplify the history by first-parent
@@ -152,9 +150,14 @@ impl<'repo> Revwalk<'repo> {
 impl<'repo> Binding for Revwalk<'repo> {
     type Raw = *mut raw::git_revwalk;
     unsafe fn from_raw(raw: *mut raw::git_revwalk) -> Revwalk<'repo> {
-        Revwalk { raw: raw, _marker: marker::PhantomData }
+        Revwalk {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_revwalk { self.raw }
+    fn raw(&self) -> *mut raw::git_revwalk {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Revwalk<'repo> {
@@ -166,7 +169,9 @@ impl<'repo> Drop for Revwalk<'repo> {
 impl<'repo> Iterator for Revwalk<'repo> {
     type Item = Result<Oid, Error>;
     fn next(&mut self) -> Option<Result<Oid, Error>> {
-        let mut out: raw::git_oid = raw::git_oid{ id: [0; raw::GIT_OID_RAWSZ] };
+        let mut out: raw::git_oid = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
             try_call_iter!(raw::git_revwalk_next(&mut out, self.raw()));
             Some(Ok(Binding::from_raw(&out as *const _)))
@@ -185,8 +190,7 @@ mod tests {
         let mut walk = repo.revwalk().unwrap();
         walk.push(target).unwrap();
 
-        let oids: Vec<::Oid> = walk.by_ref().collect::<Result<Vec<_>, _>>()
-                                            .unwrap();
+        let oids: Vec<::Oid> = walk.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
 
         assert_eq!(oids.len(), 1);
         assert_eq!(oids[0], target);

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -115,9 +115,9 @@ impl<'a> Binding for Signature<'a> {
 ///
 /// This function is unsafe as there is no guarantee that `raw` is valid for
 /// `'a` nor if it's a valid pointer.
-pub unsafe fn from_raw_const<'b, T>(_lt: &'b T,
+pub unsafe fn from_raw_const<T>(_lt: &T,
                                     raw: *const raw::git_signature)
-                                    -> Signature<'b> {
+                                    -> Signature {
     Signature {
         raw: raw as *mut raw::git_signature,
         _marker: marker::PhantomData,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -45,16 +45,19 @@ impl<'a> Signature<'a> {
     /// the time zone offset in minutes.
     ///
     /// Returns error if either `name` or `email` contain angle brackets.
-    pub fn new(name: &str, email: &str, time: &Time)
-               -> Result<Signature<'static>, Error> {
+    pub fn new(name: &str, email: &str, time: &Time) -> Result<Signature<'static>, Error> {
         ::init();
         let mut ret = ptr::null_mut();
         let name = try!(CString::new(name));
         let email = try!(CString::new(email));
         unsafe {
-            try_call!(raw::git_signature_new(&mut ret, name, email,
-                                             time.seconds() as raw::git_time_t,
-                                             time.offset_minutes() as libc::c_int));
+            try_call!(raw::git_signature_new(
+                &mut ret,
+                name,
+                email,
+                time.seconds() as raw::git_time_t,
+                time.offset_minutes() as libc::c_int
+            ));
             Ok(Binding::from_raw(ret))
         }
     }
@@ -107,7 +110,9 @@ impl<'a> Binding for Signature<'a> {
             owned: true,
         }
     }
-    fn raw(&self) -> *mut raw::git_signature { self.raw }
+    fn raw(&self) -> *mut raw::git_signature {
+        self.raw
+    }
 }
 
 /// Creates a new signature from the give raw pointer, tied to the lifetime
@@ -115,9 +120,7 @@ impl<'a> Binding for Signature<'a> {
 ///
 /// This function is unsafe as there is no guarantee that `raw` is valid for
 /// `'a` nor if it's a valid pointer.
-pub unsafe fn from_raw_const<T>(_lt: &T,
-                                    raw: *const raw::git_signature)
-                                    -> Signature {
+pub unsafe fn from_raw_const<T>(_lt: &T, raw: *const raw::git_signature) -> Signature {
     Signature {
         raw: raw as *mut raw::git_signature,
         _marker: marker::PhantomData,
@@ -145,13 +148,14 @@ impl<'a> Drop for Signature<'a> {
 }
 
 impl<'a> fmt::Display for Signature<'a> {
-
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} <{}>",
-               String::from_utf8_lossy(self.name_bytes()),
-               String::from_utf8_lossy(self.email_bytes()))
+        write!(
+            f,
+            "{} <{}>",
+            String::from_utf8_lossy(self.name_bytes()),
+            String::from_utf8_lossy(self.email_bytes())
+        )
     }
-
 }
 
 #[cfg(test)]

--- a/src/stash.rs
+++ b/src/stash.rs
@@ -1,8 +1,8 @@
-use {raw, panic, Oid, StashApplyProgress};
-use std::ffi::{CStr};
-use util::{Binding};
-use libc::{c_int, c_char, size_t, c_void};
-use build::{CheckoutBuilder};
+use {panic, raw, Oid, StashApplyProgress};
+use std::ffi::CStr;
+use util::Binding;
+use libc::{c_char, c_int, c_void, size_t};
+use build::CheckoutBuilder;
 use std::mem;
 
 /// Stash application progress notification function.
@@ -20,7 +20,7 @@ pub type StashCb<'a> = FnMut(usize, &str, &Oid) -> bool + 'a;
 pub struct StashApplyOptions<'cb> {
     progress: Option<Box<StashApplyProgressCb<'cb>>>,
     checkout_options: Option<CheckoutBuilder<'cb>>,
-    raw_opts: raw::git_stash_apply_options
+    raw_opts: raw::git_stash_apply_options,
 }
 
 impl<'cb> Default for StashApplyOptions<'cb> {
@@ -37,9 +37,10 @@ impl<'cb> StashApplyOptions<'cb> {
             checkout_options: None,
             raw_opts: unsafe { mem::zeroed() },
         };
-        assert_eq!(unsafe {
-            raw::git_stash_apply_init_options(&mut opts.raw_opts, 1)
-        }, 0);
+        assert_eq!(
+            unsafe { raw::git_stash_apply_init_options(&mut opts.raw_opts, 1) },
+            0
+        );
         opts
     }
 
@@ -60,7 +61,8 @@ impl<'cb> StashApplyOptions<'cb> {
     /// Return `true` to continue processing, or `false` to
     /// abort the stash application.
     pub fn progress_cb<C>(&mut self, callback: C) -> &mut StashApplyOptions<'cb>
-        where C: FnMut(StashApplyProgress) -> bool + 'cb
+    where
+        C: FnMut(StashApplyProgress) -> bool + 'cb,
     {
         self.progress = Some(Box::new(callback) as Box<StashApplyProgressCb<'cb>>);
         self.raw_opts.progress_cb = stash_apply_progress_cb;
@@ -81,26 +83,32 @@ impl<'cb> StashApplyOptions<'cb> {
 
 #[allow(unused)]
 pub struct StashCbData<'a> {
-    pub callback: &'a mut StashCb<'a>
+    pub callback: &'a mut StashCb<'a>,
 }
 
 #[allow(unused)]
-pub extern fn stash_cb(index: size_t,
-                        message: *const c_char,
-                        stash_id: *const raw::git_oid,
-                        payload: *mut c_void)
-                        -> c_int
-{
+pub extern "C" fn stash_cb(
+    index: size_t,
+    message: *const c_char,
+    stash_id: *const raw::git_oid,
+    payload: *mut c_void,
+) -> c_int {
     panic::wrap(|| unsafe {
         let mut data = &mut *(payload as *mut StashCbData);
         let res = {
             let mut callback = &mut data.callback;
-            callback(index,
-                     CStr::from_ptr(message).to_str().unwrap(),
-                     &Binding::from_raw(stash_id))
+            callback(
+                index,
+                CStr::from_ptr(message).to_str().unwrap(),
+                &Binding::from_raw(stash_id),
+            )
         };
 
-        if res { 0 } else { 1 }
+        if res {
+            0
+        } else {
+            1
+        }
     }).unwrap_or(1)
 }
 
@@ -115,15 +123,15 @@ fn convert_progress(progress: raw::git_stash_apply_progress_t) -> StashApplyProg
         raw::GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED => StashApplyProgress::CheckoutModified,
         raw::GIT_STASH_APPLY_PROGRESS_DONE => StashApplyProgress::Done,
 
-        _ => StashApplyProgress::None
+        _ => StashApplyProgress::None,
     }
 }
 
 #[allow(unused)]
-extern fn stash_apply_progress_cb(progress: raw::git_stash_apply_progress_t,
-                                  payload: *mut c_void)
-                                  -> c_int
-{
+extern "C" fn stash_apply_progress_cb(
+    progress: raw::git_stash_apply_progress_t,
+    payload: *mut c_void,
+) -> c_int {
     panic::wrap(|| unsafe {
         let mut options = &mut *(payload as *mut StashApplyOptions);
         let res = {
@@ -131,32 +139,42 @@ extern fn stash_apply_progress_cb(progress: raw::git_stash_apply_progress_t,
             callback(convert_progress(progress))
         };
 
-        if res { 0 } else { -1 }
+        if res {
+            0
+        } else {
+            -1
+        }
     }).unwrap_or(-1)
 }
 
 #[cfg(test)]
 mod tests {
-    use stash::{StashApplyOptions};
-    use std::io::{Write};
+    use stash::StashApplyOptions;
+    use std::io::Write;
     use std::fs;
     use std::path::Path;
-    use test::{repo_init};
-    use {Repository, STATUS_WT_NEW, STASH_INCLUDE_UNTRACKED};
+    use test::repo_init;
+    use {Repository, STASH_INCLUDE_UNTRACKED, STATUS_WT_NEW};
 
-    fn make_stash<C>(next: C) where C: FnOnce(&mut Repository) {
+    fn make_stash<C>(next: C)
+    where
+        C: FnOnce(&mut Repository),
+    {
         let (_td, mut repo) = repo_init();
         let signature = repo.signature().unwrap();
 
         let p = Path::new(repo.workdir().unwrap()).join("file_b.txt");
         println!("using path {:?}", p);
-        fs::File::create(&p).unwrap()
-            .write("data".as_bytes()).unwrap();
+        fs::File::create(&p)
+            .unwrap()
+            .write("data".as_bytes())
+            .unwrap();
 
         let rel_p = Path::new("file_b.txt");
         assert!(repo.status_file(&rel_p).unwrap() == STATUS_WT_NEW);
 
-        repo.stash_save(&signature, "msg1", Some(STASH_INCLUDE_UNTRACKED)).unwrap();
+        repo.stash_save(&signature, "msg1", Some(STASH_INCLUDE_UNTRACKED))
+            .unwrap();
 
         assert!(repo.status_file(&rel_p).is_err());
 
@@ -174,7 +192,10 @@ mod tests {
 
     fn count_stash(repo: &mut Repository) -> usize {
         let mut count = 0;
-        repo.stash_foreach(|_, _, _| { count += 1; true }).unwrap();
+        repo.stash_foreach(|_, _, _| {
+            count += 1;
+            true
+        }).unwrap();
         count
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,9 +3,9 @@ use std::ops::Range;
 use std::marker;
 use std::mem;
 use std::str;
-use libc::{c_char, size_t, c_uint};
+use libc::{c_char, c_uint, size_t};
 
-use {raw, Status, DiffDelta, IntoCString, Repository};
+use {raw, DiffDelta, IntoCString, Repository, Status};
 use util::Binding;
 
 /// Options that can be provided to `repo.statuses()` to control how the status
@@ -69,8 +69,7 @@ impl StatusOptions {
     pub fn new() -> StatusOptions {
         unsafe {
             let mut raw = mem::zeroed();
-            let r = raw::git_status_init_options(&mut raw,
-                                raw::GIT_STATUS_OPTIONS_VERSION);
+            let r = raw::git_status_init_options(&mut raw, raw::GIT_STATUS_OPTIONS_VERSION);
             assert_eq!(r, 0);
             StatusOptions {
                 raw: raw,
@@ -98,16 +97,14 @@ impl StatusOptions {
     /// If the `disable_pathspec_match` option is given, then this is a literal
     /// path to match. If this is not called, then there will be no patterns to
     /// match and the entire directory will be used.
-    pub fn pathspec<T: IntoCString>(&mut self, pathspec: T)
-                                    -> &mut StatusOptions {
+    pub fn pathspec<T: IntoCString>(&mut self, pathspec: T) -> &mut StatusOptions {
         let s = pathspec.into_c_string().unwrap();
         self.ptrs.push(s.as_ptr());
         self.pathspec.push(s);
         self
     }
 
-    fn flag(&mut self, flag: raw::git_status_opt_t, val: bool)
-            -> &mut StatusOptions {
+    fn flag(&mut self, flag: raw::git_status_opt_t, val: bool) -> &mut StatusOptions {
         if val {
             self.raw.flags |= flag as c_uint;
         } else {
@@ -149,55 +146,47 @@ impl StatusOptions {
     ///
     /// Normally if an entire directory is new then just the top-level directory
     /// is included (with a trailing slash on the entry name).
-    pub fn recurse_untracked_dirs(&mut self, include: bool)
-                                  -> &mut StatusOptions {
+    pub fn recurse_untracked_dirs(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS, include)
     }
 
     /// Indicates that the given paths should be treated as literals paths, note
     /// patterns.
-    pub fn disable_pathspec_match(&mut self, include: bool)
-                                  -> &mut StatusOptions {
+    pub fn disable_pathspec_match(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH, include)
     }
 
     /// Indicates that the contents of ignored directories should be included in
     /// the status.
-    pub fn recurse_ignored_dirs(&mut self, include: bool)
-                                -> &mut StatusOptions {
+    pub fn recurse_ignored_dirs(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_RECURSE_IGNORED_DIRS, include)
     }
 
     /// Indicates that rename detection should be processed between the head.
-    pub fn renames_head_to_index(&mut self, include: bool)
-                                 -> &mut StatusOptions {
+    pub fn renames_head_to_index(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX, include)
     }
 
     /// Indicates that rename detection should be run between the index and the
     /// working directory.
-    pub fn renames_index_to_workdir(&mut self, include: bool)
-                                    -> &mut StatusOptions {
+    pub fn renames_index_to_workdir(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR, include)
     }
 
     /// Override the native case sensitivity for the file system and force the
     /// output to be in case sensitive order.
-    pub fn sort_case_sensitively(&mut self, include: bool)
-                                 -> &mut StatusOptions {
+    pub fn sort_case_sensitively(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_SORT_CASE_SENSITIVELY, include)
     }
 
     /// Override the native case sensitivity for the file system and force the
     /// output to be in case-insensitive order.
-    pub fn sort_case_insensitively(&mut self, include: bool)
-                                   -> &mut StatusOptions {
+    pub fn sort_case_insensitively(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY, include)
     }
 
     /// Indicates that rename detection should include rewritten files.
-    pub fn renames_from_rewrites(&mut self, include: bool)
-                                 -> &mut StatusOptions {
+    pub fn renames_from_rewrites(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_RENAMES_FROM_REWRITES, include)
     }
 
@@ -223,8 +212,7 @@ impl StatusOptions {
 
     // erm...
     #[allow(missing_docs)]
-    pub fn include_unreadable_as_untracked(&mut self, include: bool)
-                                           -> &mut StatusOptions {
+    pub fn include_unreadable_as_untracked(&mut self, include: bool) -> &mut StatusOptions {
         self.flag(raw::GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED, include)
     }
 
@@ -275,14 +263,21 @@ impl<'repo> Statuses<'repo> {
 impl<'repo> Binding for Statuses<'repo> {
     type Raw = *mut raw::git_status_list;
     unsafe fn from_raw(raw: *mut raw::git_status_list) -> Statuses<'repo> {
-        Statuses { raw: raw, _marker: marker::PhantomData }
+        Statuses {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_status_list { self.raw }
+    fn raw(&self) -> *mut raw::git_status_list {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Statuses<'repo> {
     fn drop(&mut self) {
-        unsafe { raw::git_status_list_free(self.raw); }
+        unsafe {
+            raw::git_status_list_free(self.raw);
+        }
     }
 }
 
@@ -291,7 +286,9 @@ impl<'a> Iterator for StatusIter<'a> {
     fn next(&mut self) -> Option<StatusEntry<'a>> {
         self.range.next().and_then(|i| self.statuses.get(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'a> DoubleEndedIterator for StatusIter<'a> {
     fn next_back(&mut self) -> Option<StatusEntry<'a>> {
@@ -315,7 +312,9 @@ impl<'statuses> StatusEntry<'statuses> {
     /// Access this entry's path name as a string.
     ///
     /// Returns `None` if the path is not valid utf-8.
-    pub fn path(&self) -> Option<&str> { str::from_utf8(self.path_bytes()).ok() }
+    pub fn path(&self) -> Option<&str> {
+        str::from_utf8(self.path_bytes()).ok()
+    }
 
     /// Access the status flags for this file
     pub fn status(&self) -> Status {
@@ -325,28 +324,28 @@ impl<'statuses> StatusEntry<'statuses> {
     /// Access detailed information about the differences between the file in
     /// HEAD and the file in the index.
     pub fn head_to_index(&self) -> Option<DiffDelta<'statuses>> {
-        unsafe {
-            Binding::from_raw_opt((*self.raw).head_to_index)
-        }
+        unsafe { Binding::from_raw_opt((*self.raw).head_to_index) }
     }
 
     /// Access detailed information about the differences between the file in
     /// the index and the file in the working directory.
     pub fn index_to_workdir(&self) -> Option<DiffDelta<'statuses>> {
-        unsafe {
-            Binding::from_raw_opt((*self.raw).index_to_workdir)
-        }
+        unsafe { Binding::from_raw_opt((*self.raw).index_to_workdir) }
     }
 }
 
 impl<'statuses> Binding for StatusEntry<'statuses> {
     type Raw = *const raw::git_status_entry;
 
-    unsafe fn from_raw(raw: *const raw::git_status_entry)
-                           -> StatusEntry<'statuses> {
-        StatusEntry { raw: raw, _marker: marker::PhantomData }
+    unsafe fn from_raw(raw: *const raw::git_status_entry) -> StatusEntry<'statuses> {
+        StatusEntry {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *const raw::git_status_entry { self.raw }
+    fn raw(&self) -> *const raw::git_status_entry {
+        self.raw
+    }
 }
 
 #[cfg(test)]
@@ -379,8 +378,7 @@ mod tests {
         t!(File::create(&td.path().join("foo")));
         t!(File::create(&td.path().join("bar")));
         let mut opts = StatusOptions::new();
-        opts.include_untracked(true)
-            .pathspec("foo");
+        opts.include_untracked(true).pathspec("foo");
 
         let statuses = t!(repo.statuses(Some(&mut opts)));
         assert_eq!(statuses.iter().count(), 1);

--- a/src/string_array.rs
+++ b/src/string_array.rs
@@ -50,20 +50,30 @@ impl StringArray {
     /// The iterator yields `Option<&str>` as it is unknown whether the contents
     /// are utf-8 or not.
     pub fn iter(&self) -> Iter {
-        Iter { range: 0..self.len(), arr: self }
+        Iter {
+            range: 0..self.len(),
+            arr: self,
+        }
     }
 
     /// Returns an iterator over the strings contained within this array,
     /// yielding byte slices.
     pub fn iter_bytes(&self) -> IterBytes {
-        IterBytes { range: 0..self.len(), arr: self }
+        IterBytes {
+            range: 0..self.len(),
+            arr: self,
+        }
     }
 
     /// Returns the number of strings in this array.
-    pub fn len(&self) -> usize { self.raw.count as usize }
+    pub fn len(&self) -> usize {
+        self.raw.count as usize
+    }
 
     /// Return `true` if this array is empty.
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl Binding for StringArray {
@@ -71,7 +81,9 @@ impl Binding for StringArray {
     unsafe fn from_raw(raw: raw::git_strarray) -> StringArray {
         StringArray { raw: raw }
     }
-    fn raw(&self) -> raw::git_strarray { self.raw }
+    fn raw(&self) -> raw::git_strarray {
+        self.raw
+    }
 }
 
 impl<'a> IntoIterator for &'a StringArray {
@@ -87,7 +99,9 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<Option<&'a str>> {
         self.range.next().map(|i| self.arr.get(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'a> DoubleEndedIterator for Iter<'a> {
     fn next_back(&mut self) -> Option<Option<&'a str>> {
@@ -101,7 +115,9 @@ impl<'a> Iterator for IterBytes<'a> {
     fn next(&mut self) -> Option<&'a [u8]> {
         self.range.next().and_then(|i| self.arr.get_bytes(i))
     }
-    fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
 }
 impl<'a> DoubleEndedIterator for IterBytes<'a> {
     fn next_back(&mut self) -> Option<&'a [u8]> {

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -5,7 +5,7 @@ use std::str;
 use std::os::raw::c_int;
 use std::path::Path;
 
-use {raw, Oid, Repository, Error, FetchOptions};
+use {raw, Error, FetchOptions, Oid, Repository};
 use build::CheckoutBuilder;
 use util::{self, Binding};
 
@@ -30,33 +30,31 @@ impl<'repo> Submodule<'repo> {
     ///
     /// Returns `None` if the branch is not yet available.
     pub fn branch_bytes(&self) -> Option<&[u8]> {
-        unsafe {
-            ::opt_bytes(self, raw::git_submodule_branch(self.raw))
-        }
+        unsafe { ::opt_bytes(self, raw::git_submodule_branch(self.raw)) }
     }
 
     /// Get the submodule's url.
     ///
     /// Returns `None` if the url is not valid utf-8
-    pub fn url(&self) -> Option<&str> { str::from_utf8(self.url_bytes()).ok() }
+    pub fn url(&self) -> Option<&str> {
+        str::from_utf8(self.url_bytes()).ok()
+    }
 
     /// Get the url for the submodule.
     pub fn url_bytes(&self) -> &[u8] {
-        unsafe {
-            ::opt_bytes(self, raw::git_submodule_url(self.raw)).unwrap()
-        }
+        unsafe { ::opt_bytes(self, raw::git_submodule_url(self.raw)).unwrap() }
     }
 
     /// Get the submodule's name.
     ///
     /// Returns `None` if the name is not valid utf-8
-    pub fn name(&self) -> Option<&str> { str::from_utf8(self.name_bytes()).ok() }
+    pub fn name(&self) -> Option<&str> {
+        str::from_utf8(self.name_bytes()).ok()
+    }
 
     /// Get the name for the submodule.
     pub fn name_bytes(&self) -> &[u8] {
-        unsafe {
-            ::opt_bytes(self, raw::git_submodule_name(self.raw)).unwrap()
-        }
+        unsafe { ::opt_bytes(self, raw::git_submodule_name(self.raw)).unwrap() }
     }
 
     /// Get the path for the submodule.
@@ -68,16 +66,12 @@ impl<'repo> Submodule<'repo> {
 
     /// Get the OID for the submodule in the current HEAD tree.
     pub fn head_id(&self) -> Option<Oid> {
-        unsafe {
-            Binding::from_raw_opt(raw::git_submodule_head_id(self.raw))
-        }
+        unsafe { Binding::from_raw_opt(raw::git_submodule_head_id(self.raw)) }
     }
 
     /// Get the OID for the submodule in the index.
     pub fn index_id(&self) -> Option<Oid> {
-        unsafe {
-            Binding::from_raw_opt(raw::git_submodule_index_id(self.raw))
-        }
+        unsafe { Binding::from_raw_opt(raw::git_submodule_index_id(self.raw)) }
     }
 
     /// Get the OID for the submodule in the current working directory.
@@ -86,9 +80,7 @@ impl<'repo> Submodule<'repo> {
     /// checked out submodule. If there are pending changes in the index or
     /// anything else, this won't notice that.
     pub fn workdir_id(&self) -> Option<Oid> {
-        unsafe {
-            Binding::from_raw_opt(raw::git_submodule_wd_id(self.raw))
-        }
+        unsafe { Binding::from_raw_opt(raw::git_submodule_wd_id(self.raw)) }
     }
 
     /// Copy submodule info into ".git/config" file.
@@ -140,7 +132,9 @@ impl<'repo> Submodule<'repo> {
     /// if you have altered the URL for the submodule (or it has been altered
     /// by a fetch of upstream changes) and you need to update your local repo.
     pub fn sync(&mut self) -> Result<(), Error> {
-        unsafe { try_call!(raw::git_submodule_sync(self.raw)); }
+        unsafe {
+            try_call!(raw::git_submodule_sync(self.raw));
+        }
         Ok(())
     }
 
@@ -163,7 +157,9 @@ impl<'repo> Submodule<'repo> {
     /// newly cloned submodule to the index to be ready to be committed (but
     /// doesn't actually do the commit).
     pub fn add_finalize(&mut self) -> Result<(), Error> {
-        unsafe { try_call!(raw::git_submodule_add_finalize(self.raw)); }
+        unsafe {
+            try_call!(raw::git_submodule_add_finalize(self.raw));
+        }
         Ok(())
     }
 
@@ -176,13 +172,18 @@ impl<'repo> Submodule<'repo> {
     ///
     /// `init` indicates if the submodule should be initialized first if it has
     /// not been initialized yet.
-    pub fn update(&mut self, init: bool,
-                  opts: Option<&mut SubmoduleUpdateOptions>)
-                  -> Result<(), Error> {
+    pub fn update(
+        &mut self,
+        init: bool,
+        opts: Option<&mut SubmoduleUpdateOptions>,
+    ) -> Result<(), Error> {
         unsafe {
             let mut raw_opts = opts.map(|o| o.raw());
-            try_call!(raw::git_submodule_update(self.raw, init as c_int,
-                raw_opts.as_mut().map_or(ptr::null_mut(), |o| o)));
+            try_call!(raw::git_submodule_update(
+                self.raw,
+                init as c_int,
+                raw_opts.as_mut().map_or(ptr::null_mut(), |o| o)
+            ));
         }
         Ok(())
     }
@@ -191,9 +192,14 @@ impl<'repo> Submodule<'repo> {
 impl<'repo> Binding for Submodule<'repo> {
     type Raw = *mut raw::git_submodule;
     unsafe fn from_raw(raw: *mut raw::git_submodule) -> Submodule<'repo> {
-        Submodule { raw: raw, _marker: marker::PhantomData }
+        Submodule {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_submodule { self.raw }
+    fn raw(&self) -> *mut raw::git_submodule {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for Submodule<'repo> {
@@ -221,8 +227,8 @@ impl<'cb> SubmoduleUpdateOptions<'cb> {
 
     unsafe fn raw(&mut self) -> raw::git_submodule_update_options {
         let mut checkout_opts: raw::git_checkout_options = mem::zeroed();
-        let init_res = raw::git_checkout_init_options(&mut checkout_opts,
-            raw::GIT_CHECKOUT_OPTIONS_VERSION);
+        let init_res =
+            raw::git_checkout_init_options(&mut checkout_opts, raw::GIT_CHECKOUT_OPTIONS_VERSION);
         assert_eq!(0, init_res);
         self.checkout_builder.configure(&mut checkout_opts);
         raw::git_submodule_update_options {
@@ -273,13 +279,13 @@ mod tests {
     fn smoke() {
         let td = TempDir::new("test").unwrap();
         let repo = Repository::init(td.path()).unwrap();
-        let mut s1 = repo.submodule("/path/to/nowhere",
-                                    Path::new("foo"), true).unwrap();
+        let mut s1 = repo.submodule("/path/to/nowhere", Path::new("foo"), true)
+            .unwrap();
         s1.init(false).unwrap();
         s1.sync().unwrap();
 
-        let s2 = repo.submodule("/path/to/nowhere",
-                                Path::new("bar"), true).unwrap();
+        let s2 = repo.submodule("/path/to/nowhere", Path::new("bar"), true)
+            .unwrap();
         drop((s1, s2));
 
         let mut submodules = repo.submodules().unwrap();
@@ -304,11 +310,11 @@ mod tests {
         let (td, repo2) = ::test::repo_init();
 
         let url = Url::from_file_path(&repo1.workdir().unwrap()).unwrap();
-        let mut s = repo2.submodule(&url.to_string(), Path::new("bar"),
-                                    true).unwrap();
+        let mut s = repo2
+            .submodule(&url.to_string(), Path::new("bar"), true)
+            .unwrap();
         t!(fs::remove_dir_all(td.path().join("bar")));
-        t!(Repository::clone(&url.to_string(),
-                             td.path().join("bar")));
+        t!(Repository::clone(&url.to_string(), td.path().join("bar")));
         t!(s.add_to_index(false));
         t!(s.add_finalize());
     }
@@ -321,11 +327,11 @@ mod tests {
         let (td, repo2) = ::test::repo_init();
 
         let url = Url::from_file_path(&repo1.workdir().unwrap()).unwrap();
-        let mut s = repo2.submodule(&url.to_string(), Path::new("bar"),
-                                    true).unwrap();
+        let mut s = repo2
+            .submodule(&url.to_string(), Path::new("bar"), true)
+            .unwrap();
         t!(fs::remove_dir_all(td.path().join("bar")));
-        t!(Repository::clone(&url.to_string(),
-                             td.path().join("bar")));
+        t!(Repository::clone(&url.to_string(), td.path().join("bar")));
         t!(s.add_to_index(false));
         t!(s.add_finalize());
         // -----------------------------------

--- a/src/submodule.rs
+++ b/src/submodule.rs
@@ -225,13 +225,12 @@ impl<'cb> SubmoduleUpdateOptions<'cb> {
             raw::GIT_CHECKOUT_OPTIONS_VERSION);
         assert_eq!(0, init_res);
         self.checkout_builder.configure(&mut checkout_opts);
-        let opts = raw::git_submodule_update_options {
+        raw::git_submodule_update_options {
             version: raw::GIT_SUBMODULE_UPDATE_OPTIONS_VERSION,
             checkout_opts,
             fetch_opts: self.fetch_opts.raw(),
             allow_fetch: self.allow_fetch as c_int,
-        };
-        opts
+        }
     }
 
     /// Set checkout options.

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -3,7 +3,7 @@ use std::mem;
 use std::ptr;
 use std::str;
 
-use {raw, signature, Error, Oid, Object, Signature, ObjectType};
+use {raw, signature, Error, Object, ObjectType, Oid, Signature};
 use util::Binding;
 
 /// A structure to represent a git [tag][1]
@@ -93,17 +93,13 @@ impl<'repo> Tag<'repo> {
 
     /// Casts this Tag to be usable as an `Object`
     pub fn as_object(&self) -> &Object<'repo> {
-        unsafe {
-            &*(self as *const _ as *const Object<'repo>)
-        }
+        unsafe { &*(self as *const _ as *const Object<'repo>) }
     }
 
     /// Consumes Tag to be returned as an `Object`
     pub fn into_object(self) -> Object<'repo> {
         assert_eq!(mem::size_of_val(&self), mem::size_of::<Object>());
-        unsafe {
-            mem::transmute(self)
-        }
+        unsafe { mem::transmute(self) }
     }
 }
 
@@ -121,9 +117,14 @@ impl<'repo> ::std::fmt::Debug for Tag<'repo> {
 impl<'repo> Binding for Tag<'repo> {
     type Raw = *mut raw::git_tag;
     unsafe fn from_raw(raw: *mut raw::git_tag) -> Tag<'repo> {
-        Tag { raw: raw, _marker: marker::PhantomData }
+        Tag {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_tag { self.raw }
+    fn raw(&self) -> *mut raw::git_tag {
+        self.raw
+    }
 }
 
 impl<'repo> Clone for Tag<'repo> {
@@ -168,7 +169,11 @@ mod tests {
         tag.into_object();
 
         repo.find_object(tag_id, None).unwrap().as_tag().unwrap();
-        repo.find_object(tag_id, None).unwrap().into_tag().ok().unwrap();
+        repo.find_object(tag_id, None)
+            .unwrap()
+            .into_tag()
+            .ok()
+            .unwrap();
 
         repo.tag_delete("foo").unwrap();
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -26,8 +26,8 @@ pub fn repo_init() -> (TempDir, Repository) {
 
         let tree = repo.find_tree(id).unwrap();
         let sig = repo.signature().unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "initial",
-                    &tree, &[]).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
     }
     (td, repo)
 }
@@ -42,17 +42,17 @@ pub fn realpath(original: &Path) -> io::Result<PathBuf> {
 }
 #[cfg(unix)]
 pub fn realpath(original: &Path) -> io::Result<PathBuf> {
-    use std::ffi::{CStr, OsString, CString};
+    use std::ffi::{CStr, CString, OsString};
     use std::os::unix::prelude::*;
     use libc::{self, c_char};
-    extern {
+    extern "C" {
         fn realpath(name: *const c_char, resolved: *mut c_char) -> *mut c_char;
     }
     unsafe {
         let cstr = try!(CString::new(original.as_os_str().as_bytes()));
         let ptr = realpath(cstr.as_ptr(), ptr::null_mut());
         if ptr.is_null() {
-            return Err(io::Error::last_os_error())
+            return Err(io::Error::last_os_error());
         }
         let bytes = CStr::from_ptr(ptr).to_bytes().to_vec();
         libc::free(ptr as *mut _);

--- a/src/time.rs
+++ b/src/time.rs
@@ -29,10 +29,14 @@ impl Time {
     }
 
     /// Return the time, in seconds, from epoch
-    pub fn seconds(&self) -> i64 { self.raw.time as i64 }
+    pub fn seconds(&self) -> i64 {
+        self.raw.time as i64
+    }
 
     /// Return the timezone offset, in minutes
-    pub fn offset_minutes(&self) -> i32 { self.raw.offset as i32 }
+    pub fn offset_minutes(&self) -> i32 {
+        self.raw.offset as i32
+    }
 }
 
 impl PartialOrd for Time {
@@ -52,7 +56,9 @@ impl Binding for Time {
     unsafe fn from_raw(raw: raw::git_time) -> Time {
         Time { raw: raw }
     }
-    fn raw(&self) -> raw::git_time { self.raw }
+    fn raw(&self) -> raw::git_time {
+        self.raw
+    }
 }
 
 impl IndexTime {
@@ -67,9 +73,13 @@ impl IndexTime {
     }
 
     /// Returns the number of seconds in the second component of this time.
-    pub fn seconds(&self) -> i32 { self.raw.seconds }
+    pub fn seconds(&self) -> i32 {
+        self.raw.seconds
+    }
     /// Returns the nanosecond component of this time.
-    pub fn nanoseconds(&self) -> u32 { self.raw.nanoseconds }
+    pub fn nanoseconds(&self) -> u32 {
+        self.raw.nanoseconds
+    }
 }
 
 impl Binding for IndexTime {
@@ -77,7 +87,9 @@ impl Binding for IndexTime {
     unsafe fn from_raw(raw: raw::git_index_time) -> IndexTime {
         IndexTime { raw: raw }
     }
-    fn raw(&self) -> raw::git_index_time { self.raw }
+    fn raw(&self) -> raw::git_index_time {
+        self.raw
+    }
 }
 
 impl PartialOrd for IndexTime {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7,9 +7,9 @@ use std::mem;
 use std::slice;
 use std::ptr;
 use std::str;
-use libc::{c_int, c_void, c_uint, c_char, size_t};
+use libc::{c_char, c_int, c_uint, c_void, size_t};
 
-use {raw, panic, Error, Remote};
+use {panic, raw, Error, Remote};
 use util::Binding;
 
 /// A transport is a structure which knows how to transfer data to and from a
@@ -39,8 +39,7 @@ pub trait SmartSubtransport: Send + 'static {
     /// This function is responsible for making any network connections and
     /// returns a stream which can be read and written from in order to
     /// negotiate the git protocol.
-    fn action(&self, url: &str, action: Service)
-              -> Result<Box<SmartSubtransportStream>, Error>;
+    fn action(&self, url: &str, action: Service) -> Result<Box<SmartSubtransportStream>, Error>;
 
     /// Terminates a connection with the remote.
     ///
@@ -73,8 +72,7 @@ pub trait SmartSubtransportStream: Read + Write + Send + 'static {}
 
 impl<T: Read + Write + Send + 'static> SmartSubtransportStream for T {}
 
-type TransportFactory = Fn(&Remote) -> Result<Transport, Error> + Send + Sync +
-                                        'static;
+type TransportFactory = Fn(&Remote) -> Result<Transport, Error> + Send + Sync + 'static;
 
 /// Boxed data payload used for registering new transports.
 ///
@@ -105,16 +103,19 @@ struct RawSmartSubtransportStream {
 /// This function is unsafe as it needs to be externally synchronized with calls
 /// to creation of other transports.
 pub unsafe fn register<F>(prefix: &str, factory: F) -> Result<(), Error>
-    where F: Fn(&Remote) -> Result<Transport, Error> + Send + Sync + 'static
+where
+    F: Fn(&Remote) -> Result<Transport, Error> + Send + Sync + 'static,
 {
     let mut data = Box::new(TransportData {
         factory: Box::new(factory),
     });
     let prefix = try!(CString::new(prefix));
     let datap = (&mut *data) as *mut TransportData as *mut c_void;
-    try_call!(raw::git_transport_register(prefix,
-                                          transport_factory,
-                                          datap));
+    try_call!(raw::git_transport_register(
+        prefix,
+        transport_factory,
+        datap
+    ));
     mem::forget(data);
     Ok(())
 }
@@ -130,10 +131,9 @@ impl Transport {
     ///
     /// The `rpc` argument is `true` if the protocol is stateless, false
     /// otherwise. For example `http://` is stateless but `git://` is not.
-    pub fn smart<S>(remote: &Remote,
-                    rpc: bool,
-                    subtransport: S) -> Result<Transport, Error>
-        where S: SmartSubtransport
+    pub fn smart<S>(remote: &Remote, rpc: bool, subtransport: S) -> Result<Transport, Error>
+    where
+        S: SmartSubtransport,
     {
         let mut ret = ptr::null_mut();
 
@@ -160,15 +160,23 @@ impl Transport {
         // `RawSmartSubtransport`). This also means that this block must be
         // entirely synchronized with a lock (boo!)
         unsafe {
-            try_call!(raw::git_transport_smart(&mut ret, remote.raw(),
-                                               &mut defn as *mut _ as *mut _));
+            try_call!(raw::git_transport_smart(
+                &mut ret,
+                remote.raw(),
+                &mut defn as *mut _ as *mut _
+            ));
             mem::forget(raw); // ownership transport to `ret`
         }
-        return Ok(Transport { raw: ret, owned: true });
+        return Ok(Transport {
+            raw: ret,
+            owned: true,
+        });
 
-        extern fn smart_factory(out: *mut *mut raw::git_smart_subtransport,
-                                _owner: *mut raw::git_transport,
-                                ptr: *mut c_void) -> c_int {
+        extern "C" fn smart_factory(
+            out: *mut *mut raw::git_smart_subtransport,
+            _owner: *mut raw::git_transport,
+            ptr: *mut c_void,
+        ) -> c_int {
             unsafe {
                 *out = ptr as *mut raw::git_smart_subtransport;
                 0
@@ -180,18 +188,20 @@ impl Transport {
 impl Drop for Transport {
     fn drop(&mut self) {
         if self.owned {
-            unsafe {
-                ((*self.raw).free)(self.raw)
-            }
+            unsafe { ((*self.raw).free)(self.raw) }
         }
     }
 }
 
 // callback used by register() to create new transports
-extern fn transport_factory(out: *mut *mut raw::git_transport,
-                            owner: *mut raw::git_remote,
-                            param: *mut c_void) -> c_int {
-    struct Bomb<'a> { remote: Option<Remote<'a>> }
+extern "C" fn transport_factory(
+    out: *mut *mut raw::git_transport,
+    owner: *mut raw::git_remote,
+    param: *mut c_void,
+) -> c_int {
+    struct Bomb<'a> {
+        remote: Option<Remote<'a>>,
+    }
     impl<'a> Drop for Bomb<'a> {
         fn drop(&mut self) {
             // TODO: maybe a method instead?
@@ -200,7 +210,9 @@ extern fn transport_factory(out: *mut *mut raw::git_transport,
     }
 
     panic::wrap(|| unsafe {
-        let remote = Bomb { remote: Some(Binding::from_raw(owner)) };
+        let remote = Bomb {
+            remote: Some(Binding::from_raw(owner)),
+        };
         let data = &mut *(param as *mut TransportData);
         match (data.factory)(remote.remote.as_ref().unwrap()) {
             Ok(mut transport) => {
@@ -215,10 +227,12 @@ extern fn transport_factory(out: *mut *mut raw::git_transport,
 
 // callback used by smart transports to delegate an action to a
 // `SmartSubtransport` trait object.
-extern fn subtransport_action(stream: *mut *mut raw::git_smart_subtransport_stream,
-                              raw_transport: *mut raw::git_smart_subtransport,
-                              url: *const c_char,
-                              action: raw::git_smart_service_t) -> c_int {
+extern "C" fn subtransport_action(
+    stream: *mut *mut raw::git_smart_subtransport_stream,
+    raw_transport: *mut raw::git_smart_subtransport,
+    url: *const c_char,
+    action: raw::git_smart_service_t,
+) -> c_int {
     panic::wrap(|| unsafe {
         let url = CStr::from_ptr(url).to_bytes();
         let url = match str::from_utf8(url).ok() {
@@ -252,8 +266,7 @@ extern fn subtransport_action(stream: *mut *mut raw::git_smart_subtransport_stre
 
 // callback used by smart transports to close a `SmartSubtransport` trait
 // object.
-extern fn subtransport_close(transport: *mut raw::git_smart_subtransport)
-                             -> c_int {
+extern "C" fn subtransport_close(transport: *mut raw::git_smart_subtransport) -> c_int {
     let ret = panic::wrap(|| unsafe {
         let transport = &mut *(transport as *mut RawSmartSubtransport);
         transport.obj.close()
@@ -267,7 +280,7 @@ extern fn subtransport_close(transport: *mut raw::git_smart_subtransport)
 
 // callback used by smart transports to free a `SmartSubtransport` trait
 // object.
-extern fn subtransport_free(transport: *mut raw::git_smart_subtransport) {
+extern "C" fn subtransport_free(transport: *mut raw::git_smart_subtransport) {
     let _ = panic::wrap(|| unsafe {
         mem::transmute::<_, Box<RawSmartSubtransport>>(transport);
     });
@@ -275,31 +288,40 @@ extern fn subtransport_free(transport: *mut raw::git_smart_subtransport) {
 
 // callback used by smart transports to read from a `SmartSubtransportStream`
 // object.
-extern fn stream_read(stream: *mut raw::git_smart_subtransport_stream,
-                      buffer: *mut c_char,
-                      buf_size: size_t,
-                      bytes_read: *mut size_t) -> c_int {
+extern "C" fn stream_read(
+    stream: *mut raw::git_smart_subtransport_stream,
+    buffer: *mut c_char,
+    buf_size: size_t,
+    bytes_read: *mut size_t,
+) -> c_int {
     let ret = panic::wrap(|| unsafe {
         let transport = &mut *(stream as *mut RawSmartSubtransportStream);
-        let buf = slice::from_raw_parts_mut(buffer as *mut u8,
-                                            buf_size as usize);
+        let buf = slice::from_raw_parts_mut(buffer as *mut u8, buf_size as usize);
         match transport.obj.read(buf) {
-            Ok(n) => { *bytes_read = n as size_t; Ok(n) }
+            Ok(n) => {
+                *bytes_read = n as size_t;
+                Ok(n)
+            }
             e => e,
         }
     });
     match ret {
         Some(Ok(_)) => 0,
-        Some(Err(e)) => unsafe { set_err(&e); -2 },
+        Some(Err(e)) => unsafe {
+            set_err(&e);
+            -2
+        },
         None => -1,
     }
 }
 
 // callback used by smart transports to write to a `SmartSubtransportStream`
 // object.
-extern fn stream_write(stream: *mut raw::git_smart_subtransport_stream,
-                       buffer: *const c_char,
-                       len: size_t) -> c_int {
+extern "C" fn stream_write(
+    stream: *mut raw::git_smart_subtransport_stream,
+    buffer: *const c_char,
+    len: size_t,
+) -> c_int {
     let ret = panic::wrap(|| unsafe {
         let transport = &mut *(stream as *mut RawSmartSubtransportStream);
         let buf = slice::from_raw_parts(buffer as *const u8, len as usize);
@@ -307,7 +329,10 @@ extern fn stream_write(stream: *mut raw::git_smart_subtransport_stream,
     });
     match ret {
         Some(Ok(())) => 0,
-        Some(Err(e)) => unsafe { set_err(&e); -2 },
+        Some(Err(e)) => unsafe {
+            set_err(&e);
+            -2
+        },
         None => -1,
     }
 }
@@ -319,7 +344,7 @@ unsafe fn set_err(e: &io::Error) {
 
 // callback used by smart transports to free a `SmartSubtransportStream`
 // object.
-extern fn stream_free(stream: *mut raw::git_smart_subtransport_stream) {
+extern "C" fn stream_free(stream: *mut raw::git_smart_subtransport_stream) {
     let _ = panic::wrap(|| unsafe {
         mem::transmute::<_, Box<RawSmartSubtransportStream>>(stream);
     });

--- a/src/treebuilder.rs
+++ b/src/treebuilder.rs
@@ -30,7 +30,8 @@ impl<'repo> TreeBuilder<'repo> {
 
     /// Get en entry from the builder from its filename
     pub fn get<P>(&self, filename: P) -> Result<Option<TreeEntry>, Error>
-        where P: IntoCString
+    where
+        P: IntoCString,
     {
         let filename = try!(filename.into_c_string());
         unsafe {
@@ -50,15 +51,24 @@ impl<'repo> TreeBuilder<'repo> {
     ///
     /// The mode given must be one of 0o040000, 0o100644, 0o100755, 0o120000 or
     /// 0o160000 currently.
-    pub fn insert<P: IntoCString>(&mut self, filename: P, oid: Oid,
-                                  filemode: i32) -> Result<TreeEntry, Error> {
+    pub fn insert<P: IntoCString>(
+        &mut self,
+        filename: P,
+        oid: Oid,
+        filemode: i32,
+    ) -> Result<TreeEntry, Error> {
         let filename = try!(filename.into_c_string());
         let filemode = filemode as raw::git_filemode_t;
 
         let mut ret = ptr::null();
         unsafe {
-            try_call!(raw::git_treebuilder_insert(&mut ret, self.raw, filename,
-                                                  oid.raw(), filemode));
+            try_call!(raw::git_treebuilder_insert(
+                &mut ret,
+                self.raw,
+                filename,
+                oid.raw(),
+                filemode
+            ));
             Ok(tree::entry_from_raw_const(ret))
         }
     }
@@ -77,7 +87,8 @@ impl<'repo> TreeBuilder<'repo> {
     /// Values for which the filter returns `true` will be kept.  Note
     /// that this behavior is different from the libgit2 C interface.
     pub fn filter<F>(&mut self, mut filter: F)
-        where F: FnMut(&TreeEntry) -> bool
+    where
+        F: FnMut(&TreeEntry) -> bool,
     {
         let mut cb: &mut FilterCb = &mut filter;
         let ptr = &mut cb as *mut _;
@@ -90,7 +101,9 @@ impl<'repo> TreeBuilder<'repo> {
     /// Write the contents of the TreeBuilder as a Tree object and
     /// return its Oid
     pub fn write(&self) -> Result<Oid, Error> {
-        let mut raw = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
+        let mut raw = raw::git_oid {
+            id: [0; raw::GIT_OID_RAWSZ],
+        };
         unsafe {
             try_call!(raw::git_treebuilder_write(&mut raw, self.raw()));
             Ok(Binding::from_raw(&raw as *const _))
@@ -100,8 +113,7 @@ impl<'repo> TreeBuilder<'repo> {
 
 type FilterCb<'a> = FnMut(&TreeEntry) -> bool + 'a;
 
-extern fn filter_cb(entry: *const raw::git_tree_entry,
-                    payload: *mut c_void) -> c_int {
+extern "C" fn filter_cb(entry: *const raw::git_tree_entry, payload: *mut c_void) -> c_int {
     let ret = panic::wrap(|| unsafe {
         // There's no way to return early from git_treebuilder_filter.
         if panic::panicked() {
@@ -112,16 +124,25 @@ extern fn filter_cb(entry: *const raw::git_tree_entry,
             (*payload)(&entry)
         }
     });
-    if ret == Some(false) {1} else {0}
+    if ret == Some(false) {
+        1
+    } else {
+        0
+    }
 }
 
 impl<'repo> Binding for TreeBuilder<'repo> {
     type Raw = *mut raw::git_treebuilder;
 
     unsafe fn from_raw(raw: *mut raw::git_treebuilder) -> TreeBuilder<'repo> {
-        TreeBuilder { raw: raw, _marker: marker::PhantomData }
+        TreeBuilder {
+            raw: raw,
+            _marker: marker::PhantomData,
+        }
     }
-    fn raw(&self) -> *mut raw::git_treebuilder { self.raw }
+    fn raw(&self) -> *mut raw::git_treebuilder {
+        self.raw
+    }
 }
 
 impl<'repo> Drop for TreeBuilder<'repo> {
@@ -180,8 +201,7 @@ mod tests {
         let mut builder = repo.treebuilder(None).unwrap();
         let blob = repo.blob(b"data").unwrap();
         let tree = {
-            let head = repo.head().unwrap()
-                .peel(ObjectType::Commit).unwrap();
+            let head = repo.head().unwrap().peel(ObjectType::Commit).unwrap();
             let head = head.as_commit().unwrap();
             head.tree_id()
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,7 +28,9 @@ pub trait Binding: Sized {
     fn raw(&self) -> Self::Raw;
 
     unsafe fn from_raw_opt<T>(raw: T) -> Option<Self>
-        where T: Copy + IsNull, Self: Binding<Raw=T>
+    where
+        T: Copy + IsNull,
+        Self: Binding<Raw = T>,
     {
         if raw.is_ptr_null() {
             None
@@ -38,9 +40,12 @@ pub trait Binding: Sized {
     }
 }
 
-pub fn iter2cstrs<T, I>(iter: I) -> Result<(Vec<CString>, Vec<*const c_char>,
-                                            raw::git_strarray), Error>
-    where T: IntoCString, I: IntoIterator<Item=T>
+pub fn iter2cstrs<T, I>(
+    iter: I,
+) -> Result<(Vec<CString>, Vec<*const c_char>, raw::git_strarray), Error>
+where
+    T: IntoCString,
+    I: IntoIterator<Item = T>,
 {
     let cstrs: Vec<_> = try!(iter.into_iter().map(|i| i.into_c_string()).collect());
     let ptrs = cstrs.iter().map(|i| i.as_ptr()).collect::<Vec<_>>();
@@ -90,7 +95,9 @@ impl IntoCString for String {
 }
 
 impl IntoCString for CString {
-    fn into_c_string(self) -> Result<CString, Error> { Ok(self) }
+    fn into_c_string(self) -> Result<CString, Error> {
+        Ok(self)
+    }
 }
 
 impl<'a> IntoCString for &'a Path {
@@ -124,8 +131,10 @@ impl IntoCString for OsString {
     fn into_c_string(self) -> Result<CString, Error> {
         match self.to_str() {
             Some(s) => s.into_c_string(),
-            None => Err(Error::from_str("only valid unicode paths are accepted \
-                                         on windows")),
+            None => Err(Error::from_str(
+                "only valid unicode paths are accepted \
+                 on windows",
+            )),
         }
     }
 }
@@ -143,7 +152,8 @@ impl IntoCString for Vec<u8> {
 }
 
 pub fn into_opt_c_string<S>(opt_s: Option<S>) -> Result<Option<CString>, Error>
-    where S: IntoCString
+where
+    S: IntoCString,
 {
     match opt_s {
         None => Ok(None),


### PR DESCRIPTION
This PR fixes a couple of minor issues found by clippy (0.0.165).

Two lints have not been touched though:
1. `match` has identical arm bodies

    For example:
    ```
    warning: this `match` has identical arm bodies
       --> src/diff.rs:839:18
        |
    839 |             _ => ' ',
        |                  ^^^
        |
        = note: #[warn(match_same_arms)] on by default
    note: same as this
       --> src/diff.rs:830:43
        |
    830 |             raw::GIT_DIFF_LINE_CONTEXT => ' ',
        |                                           ^^^
    note: `raw::GIT_DIFF_LINE_CONTEXT` has the same arm body as the `_` wildcard, consider removing it`
       --> src/diff.rs:830:43
        |
    830 |             raw::GIT_DIFF_LINE_CONTEXT => ' ',
        |                                           ^^^
        = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#match_same_arms

    ```

    I feel that those matches (four of them?) are quite clear in what they do. Not sure that merging the identical arms really simplifies code.

1. The different `from_str()`

    For example:
    ```
    warning: defining a method called `from_str` on this type; consider implementing the `std::str::FromStr` trait or choosing a less
    ambiguous name
      --> src/error.rs:43:5
       |
    43 | /     pub fn from_str(s: &str) -> Error {
    44 | |         Error {
    45 | |             code: raw::GIT_ERROR as c_int,
    46 | |             klass: raw::GITERR_NONE as c_int,
    47 | |             message: s.to_string(),
    48 | |         }
    49 | |     }
       | |_____^
       |
       = note: #[warn(should_implement_trait)] on by default
       = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#should_implement_trait
    ```

    I'm not sure about those, specially the `Error` one which seems circular. There is also `Oid` which has an `from_str()` impl _and_ implements the `FromStr` trait (which calls the impl...) Shouldn't these two simply be merged?

1. A "cyclomatic complexity of 32"

    ```
    warning: the function has a cyclomatic complexity of 32
       --> src/error.rs:158:5
        |
    158 | /     pub fn raw_class(&self) -> raw::git_error_t {
    159 | |         macro_rules! check( ($($e:ident,)*) => (
    160 | |             $(if self.klass == raw::$e as c_int { raw::$e }) else *
    161 | |             else {
    ...   |
    197 | |         )
    198 | |     }
        | |_____^
        |
        = note: #[warn(cyclomatic_complexity)] on by default
        = help: you could split it up into multiple smaller functions
        = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#cyclomatic_complexity
    ```

     This one is inside a macro, which does simplifies the code.

1. `Patch::to_buf()` taking `&mut self`

    ```
    warning: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
       --> src/patch.rs:212:19
        |
    212 |     pub fn to_buf(&mut self) -> Result<Buf, Error> {
        |                   ^^^^^^^^^
        |
        = note: #[warn(wrong_self_convention)] on by default
        = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#wrong_self_convention
    ```

    Not sure what appropriate name it should take?


Nightly used: 1.22.0-nightly (dcbbfb6e8 2017-10-12)