### PR TITLE
Fix typo in Delta::Renamed's docstring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -880,7 +880,7 @@ pub enum Delta {
     Deleted,
     /// Entry content changed between old and new
     Modified,
-    /// Entry was renamed wbetween old and new
+    /// Entry was renamed between old and new
     Renamed,
     /// Entry was copied from another old entry
     Copied,


### PR DESCRIPTION
https://github.com/libgit2/libgit2/blob/6be167f13076294721b8707197ce2d049313fb0b/include/git2/diff.h#L251