### PR TITLE
Don't shutdown libgit2 at exit

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2698,11 +2698,7 @@ pub fn init() {
         let r = git_libgit2_init();
         assert!(r >= 0,
                 "couldn't initialize the libgit2 library: {}", r);
-        assert_eq!(libc::atexit(shutdown), 0);
     });
-    extern fn shutdown() {
-        unsafe { git_libgit2_shutdown(); }
-    }
 }
 
 #[cfg(all(unix, feature = "https"))]


### PR DESCRIPTION
atexit handlers can be run while other threads are still alive, and in
particular still using git2 types. This can manifest as hitting this
assert, for example:
https://github.com/libgit2/libgit2/blob/master/src/mwindow.c#L106