### PR TITLE
[Discussion / Implementation] Allow opt-in access to raw bindings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tempdir = "0.3"
 [features]
 unstable = []
 default = ["ssh", "https", "curl"]
+raw-binds = []
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
 curl = ["libgit2-sys/curl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,6 +532,12 @@ bitflags! {
 #[cfg(test)] #[macro_use] mod test;
 #[macro_use] mod panic;
 mod call;
+
+#[cfg(feature = "unsafe-binds")]
+#[allow(missing_docs)]
+pub mod util;
+
+#[cfg(not(feature = "unsafe-binds"))]
 mod util;
 
 pub mod build;


### PR DESCRIPTION
When using git2-rs for complex use cases, sometimes it may be desirable to be able to access raw libgit2 objects while still being able to consume the Rustic API. This exposes that possibility while maintaining a safe default which does not publicly expose the raw binding trait.

This more to spawn a discussion than anything else. Some library bindings expose these sorts of things to the consumer, while some don't. Luckily, Rust has a feature system which allows the consumer to choose.

Potential Problems:
- When used by a consumer, it should be very clear to them that use of these APIs is unsafe, unstable, and could change at any point in time.
- The name of the feature is potentially confusing, any recommendations would be great.
- This might be considered bad practice because any use case that is not possible with existing bindings should probably have the relevant bindings implemented.

Example Use Case:
While implementing a Git Server, I want to use the `mempack` API which allows in-memory manipulation of an object database that can then be dumped to a buffer (this is actually implemented by and used at GitHub). To bind this correctly into git2-rs, it would require substantial work to implement a full ODB backend infrastructure, which is complex to do (I've tried twice).
