### PR TITLE
libgit2-sys: Add missing git_odb_backend_malloc

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2921,6 +2921,9 @@ extern {
                                  backend: *mut git_odb_backend,
                                  priority: c_int) -> c_int;
 
+    pub fn git_odb_backend_malloc(backend: *mut git_odb_backend,
+                                  len: size_t) -> *mut c_void;
+
     pub fn git_odb_num_backends(odb: *mut git_odb) -> size_t;
     pub fn git_odb_get_backend(backend: *mut *mut git_odb_backend,
                                odb: *mut git_odb,


### PR DESCRIPTION
This function is meant to be used by backends when they need to allocate
memory:
  https://github.com/libgit2/libgit2/blob/26f5d36d2f14dc1d711ed0a2c844ef4d7887a9b3/include/git2/sys/odb_backend.h

refs #222