### PR TITLE
oid: Allow Oid to represent short oids

### DIFF
--- a/src/odb.rs
+++ b/src/odb.rs
@@ -129,21 +129,13 @@ impl<'repo> Odb<'repo> {
     }
 
     /// Potentially finds an object that starts with the given prefix.
-    ///
-    /// If `len` is 0, gets the length from `short_oid`. The `len` parameter
-    /// will be removed in the next major version.
-    pub fn exists_prefix(&self, short_oid: Oid, len: usize) -> Result<Oid, Error> {
-        let len = match len {
-            0 => short_oid.len(),
-            n => n,
-        };
-
+    pub fn exists_prefix(&self, short_oid: Oid) -> Result<Oid, Error> {
         unsafe {
             let mut out = raw::git_oid { id: [0; raw::GIT_OID_RAWSZ] };
             try_call!(raw::git_odb_exists_prefix(&mut out,
                                                  self.raw,
                                                  short_oid.raw(),
-                                                 len));
+                                                 short_oid.len()));
             Ok(Oid::from_raw(&out))
         }
     } 
@@ -419,10 +411,7 @@ mod tests {
         let id = db.write(ObjectType::Blob, &dat).unwrap();
         let id_prefix_str = &id.to_string()[0..10];
         let id_prefix = Oid::from_str(id_prefix_str).unwrap();
-        let found_oid = db.exists_prefix(id_prefix, 10).unwrap();
-        assert_eq!(found_oid, id);
-        // Check the short OID behaviour works.
-        let found_oid = db.exists_prefix(id_prefix, 0).unwrap();
+        let found_oid = db.exists_prefix(id_prefix).unwrap();
         assert_eq!(found_oid, id);
     }
 }

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -163,9 +163,11 @@ impl fmt::Display for Oid {
     /// Hex-encode this Oid into a formatter.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut dst = [0u8; raw::GIT_OID_HEXSZ + 1];
+        let len = self.len();
+        assert!(len <= raw::GIT_OID_HEXSZ);
         unsafe {
             raw::git_oid_tostr(dst.as_mut_ptr() as *mut libc::c_char,
-                               dst.len() as libc::size_t, &self.raw);
+                               self.len() + 1 as libc::size_t, &self.raw);
         }
         let s = &dst[..dst.iter().position(|&a| a == 0).unwrap()];
         str::from_utf8(s).unwrap().fmt(f)
@@ -235,8 +237,9 @@ mod tests {
         assert!(Oid::from_bytes(b"foo").is_err());
         assert!(Oid::from_bytes(b"00000000000000000000").is_ok());
 
-        let oid = Oid::from_str("abcdef123").unwrap();
+        let oid: Oid = "abcdef123".parse().unwrap();
         assert_eq!(9, oid.len());
+        assert_eq!("abcdef123", oid.to_string());
     }
 
     #[test]

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -12,7 +12,7 @@ use util::Binding;
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 enum OidLength {
     Full,
-    // This is u16 to allow this to fit into 4 bytes, making Oid 24 bytes.  Even
+    // This is u16 to allow this to fit into 4 bytes, making Oid 24 bytes. Even
     // as git changes its hash function, the digest produced will certainly be
     // shorter than 64k hex chars (32 kB). Even u8 should be fine, but giving a
     // big of headroom just in case, and anyway it'll likely align to to a

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -24,7 +24,7 @@ impl OidArray {
 
     /// Get an iterator over the `Oid`s in this array.
     pub fn iter<'a>(&'a self) -> OidIter<'a> {
-        self.into_iter()
+        OidIter { arr: self, idx: 0 }
     }
 
     fn as_raw_slice(&self) -> &[raw::git_oid] {
@@ -58,7 +58,7 @@ impl<'a> ::std::iter::IntoIterator for &'a OidArray {
     type IntoIter = OidIter<'a>;
 
     fn into_iter(self) -> OidIter<'a> {
-        OidIter { arr: self, idx: 0 }
+        self.iter()
     }
 }
 

--- a/src/oid_array.rs
+++ b/src/oid_array.rs
@@ -6,7 +6,6 @@ use oid::Oid;
 use raw;
 use util::Binding;
 use std::slice;
-use std::mem;
 
 /// An oid array structure used by libgit2
 ///
@@ -17,15 +16,49 @@ pub struct OidArray {
     raw: raw::git_oidarray,
 }
 
-impl Deref for OidArray {
-    type Target = [Oid];
+impl OidArray {
+    /// Get the length of this array.
+    pub fn len(&self) -> usize {
+        self.raw.count as usize
+    }
 
-    fn deref(&self) -> &[Oid] {
-        unsafe {
-            debug_assert_eq!(mem::size_of::<Oid>(), mem::size_of_val(&*self.raw.ids));
-            
-            slice::from_raw_parts(self.raw.ids as *const Oid, self.raw.count as usize)
+    /// Get an iterator over the `Oid`s in this array.
+    pub fn iter<'a>(&'a self) -> OidIter<'a> {
+        self.into_iter()
+    }
+
+    fn as_raw_slice(&self) -> &[raw::git_oid] {
+        unsafe { slice::from_raw_parts(self.raw.ids, self.raw.count as usize) }
+    }
+
+}
+
+/// An iterator over `OidArray`.
+pub struct OidIter<'a> {
+    arr: &'a OidArray,
+    idx: usize,
+}
+
+impl<'a> ::std::iter::Iterator for OidIter<'a> {
+    type Item = Oid;
+    fn next(&mut self) -> Option<Oid> {
+        if self.idx >= self.arr.raw.count {
+            return None;
         }
+        let arr: &[raw::git_oid] = self.arr.as_raw_slice();
+        let ret = unsafe { Oid::from_raw(&arr[self.idx] as * const _) };
+        self.idx += 1;
+
+        Some(ret)
+    }
+}
+
+impl<'a> ::std::iter::IntoIterator for &'a OidArray {
+    type Item = Oid;
+    type IntoIter = OidIter<'a>;
+
+    fn into_iter(self) -> OidIter<'a> {
+        OidIter { arr: self, idx: 0 }
     }
 }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2443,9 +2443,9 @@ mod tests {
         let mut found_oid3 = false;
         for mg in merge_bases.iter() {
             println!("found merge base {:?}", mg);
-            if mg == &oid2 {
+            if mg == oid2 {
                 found_oid2 = true;
-            } else if mg == &oid3 {
+            } else if mg == oid3 {
                 found_oid3 = true;
             } else {
                 assert!(false);


### PR DESCRIPTION
Add a `len` field to `Oid` to allow it to track if it's a short
oid to use as a prefix. This makes the `exists_prefix` API easier to
use, as you no longer need to track the length yourself.

BREAKING CHANGES:
- `Oid` now tracks its own length, allowing it to represent both short
and full oids.  As a result, `Odb::exists_prefix` no longer takes a
length parameter.
- The `OidArray` no longer implements `Deref<Target=[Oid]>`. To access
the contained oids, use the iterator returned by `OidArray::iter()`.

closes #293