### PR TITLE
Update vendored libgit2 to v0.27.0-rc1

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -1322,6 +1322,8 @@ pub struct git_odb_backend {
                                git_otype) -> c_int,
 
     pub readstream: extern fn(*mut *mut git_odb_stream,
+                              *mut size_t,
+                              *mut git_otype,
                               *mut git_odb_backend,
                               *const git_oid) -> c_int,
 
@@ -2835,6 +2837,8 @@ extern {
     pub fn git_odb_new(db: *mut *mut git_odb) -> c_int;
     pub fn git_odb_free(db: *mut git_odb);
     pub fn git_odb_open_rstream(out: *mut *mut git_odb_stream,
+                                len: *mut size_t,
+                                otype: *mut git_otype,
                                 db: *mut git_odb,
                                 oid: *const git_oid) -> c_int;
     pub fn git_odb_stream_read(stream: *mut git_odb_stream,

--- a/src/odb.rs
+++ b/src/odb.rs
@@ -49,11 +49,13 @@ impl<'repo> Odb<'repo> {
     ///
     /// Note that most backends do not support streaming reads because they store their objects as compressed/delta'ed blobs.
     /// If the backend does not support streaming reads, use the `read` method instead.
-    pub fn reader(&self, oid: Oid) -> Result<OdbReader, Error> {
+    pub fn reader(&self, oid: Oid) -> Result<(OdbReader, usize, ObjectType), Error> {
         let mut out = ptr::null_mut();
+        let mut size = 0usize;
+        let mut otype: raw::git_otype = ObjectType::Any.raw();
         unsafe {
-            try_call!(raw::git_odb_open_rstream(&mut out, self.raw, oid.raw()));
-            Ok(OdbReader::from_raw(out))
+            try_call!(raw::git_odb_open_rstream(&mut out, &mut size, &mut otype, self.raw, oid.raw()));
+            Ok((OdbReader::from_raw(out), size, ObjectType::from_raw(otype).unwrap()))
         }
     }
 


### PR DESCRIPTION
The new release should be out shortly, so here's an update to the first RC.