### PR TITLE
Add bindings for creating and extracting GPG signatures

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -2141,6 +2141,16 @@ extern {
     pub fn git_annotated_commit_lookup(out: *mut *mut git_annotated_commit,
                                        repo: *mut git_repository,
                                        id: *const git_oid) -> c_int;
+    pub fn git_commit_create_with_signature(id: *mut git_oid,
+                                            repo: *mut git_repository,
+                                            commit_content: *const c_char,
+                                            signature: *const c_char,
+                                            signature_field: *const c_char) -> c_int;
+    pub fn git_commit_extract_signature(signature: *mut git_buf,
+                                        signed_data: *mut git_buf,
+                                        repo: *mut git_repository,
+                                        commit_id: *mut git_oid,
+                                        field: *const c_char) -> c_int;
 
     // branch
     pub fn git_branch_create(out: *mut *mut git_reference,


### PR DESCRIPTION
These were added in libgit2 v24. This is a clone of #163 by cmr which was closed due to inactivity. Comments from the original PR have been addressed, including changing the method name to `commit_signed` from `signed_commit`, being explicit about the ordering of return arguments, and removing the version bump.