### PR TITLE
fix(cargo): Update minimal required dependencies

### DIFF
--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 curl-sys = { version = "0.4", optional = true }
 libc = "0.2"
 libssh2-sys = { version = "0.2.4", optional = true }
-libz-sys = ">= 0"
+libz-sys = ">= 0.1.2"
 
 [build-dependencies]
 pkg-config = "0.3"


### PR DESCRIPTION
This is necessary so that this crate compiles with `CARGO_REGISTRY_INDEX=https://github.com/klausi/crates.io-index cargo build -Z minimal-versions`

Note that the custom registry is needed because of the `links` entries that are missing on the main crates.io index.