### PR TITLE
Manifest: add excludes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ both threadsafe and memory safe and allows both reading and writing git
 repositories.
 """
 categories = ["api-bindings"]
+exclude = [
+    "libgit2/tests/*",
+]
 
 [badges]
 travis-ci = { repository = "alexcrichton/git2-rs" }


### PR DESCRIPTION
Git's test data weighs at about half of the source. Trimming this down reduces package size.