### PR TITLE
Update libgit2 to include fixes for LibreSSL 2.7

### DIFF
--- a/systest/build.rs
+++ b/systest/build.rs
@@ -30,6 +30,8 @@ fn main() {
             "git_push_transfer_progress" |
             "git_push_negotiation" |
             "git_packbuilder_progress" => true,
+            // TODO: fix this on the next major update of libgit2-sys
+            "git_diff_option_t" => true,
             _ => false,
         }
     });


### PR DESCRIPTION
I did not update it to a even newer version to no import that many
changes. Nevertheless it contains a few fixes, for a memleak
amongst other things.