### PR TITLE
Add the ssh_key_from_memory optional feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ default = ["ssh", "https", "curl"]
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
 curl = ["libgit2-sys/curl"]
+ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
 
 [workspace]
 members = ["systest", "git2-curl"]

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -33,3 +33,4 @@ openssl-sys = { version = "0.9", optional = true }
 ssh = ["libssh2-sys"]
 https = ["openssl-sys"]
 curl = ["curl-sys"]
+ssh_key_from_memory = []

--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -48,6 +48,9 @@ fn main() {
     let msvc = target.contains("msvc");
     let mut cfg = cmake::Config::new("libgit2");
 
+    #[cfg(feature = "ssh_key_from_memory")] 
+    cfg.define("GIT_SSH_MEMORY_CREDENTIALS", "1");
+
     if msvc {
         // libgit2 passes the /GL flag to enable whole program optimization, but
         // this requires that the /LTCG flag is passed to the linker later on,


### PR DESCRIPTION
Fix for https://github.com/alexcrichton/git2-rs/issues/320

This is done through a feature that will enable the `GIT_SSH_MEMORY_CREDENTIALS` flag when building `libgit2-sys`.

This feature is optional so that the current behavior is unchanged.