### PR TITLE
Added missing is_wt_deleted method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -957,6 +957,7 @@ impl Status {
     is_bit_set!(is_index_typechange, Status::INDEX_TYPECHANGE);
     is_bit_set!(is_wt_new, Status::WT_NEW);
     is_bit_set!(is_wt_modified, Status::WT_MODIFIED);
+    is_bit_set!(is_wt_deleted, Status::WT_DELETED);
     is_bit_set!(is_wt_typechange, Status::WT_TYPECHANGE);
     is_bit_set!(is_wt_renamed, Status::WT_RENAMED);
     is_bit_set!(is_ignored, Status::IGNORED);


### PR DESCRIPTION
While using this awesome binding I noticed that method ``is_wt_deleted`` is missing for the ``Status`` struct. So here's a patch for it.