### PR TITLE
work around for windows path separator for is_path_ignored

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2043,6 +2043,20 @@ impl Repository {
     }
 
     /// Test if the ignore rules apply to a given path.
+    #[cfg(windows)]
+    pub fn is_path_ignored<P: AsRef<Path>>(&self, path: P) -> Result<bool, Error> {
+        // `git_ignore_path_is_ignored` dose not work with windows path separator
+        // so we convert \ to /
+        let path = try!(::std::ffi::CString::new(path.as_ref().to_string_lossy().replace('\\', "/")));
+        let mut ignored: c_int = 0;
+        unsafe {
+            try_call!(raw::git_ignore_path_is_ignored(&mut ignored, self.raw, path));
+        }
+        Ok(ignored == 1)
+    }
+
+    /// Test if the ignore rules apply to a given path.
+    #[cfg(not(windows))]
     pub fn is_path_ignored<P: AsRef<Path>>(&self, path: P) -> Result<bool, Error> {
         let path = try!(path.as_ref().into_c_string());
         let mut ignored: c_int = 0;
@@ -2539,5 +2553,19 @@ mod tests {
 
         let _ = repo.clear_ignore_rules();
         assert!(!repo.is_path_ignored(Path::new("/foo")).unwrap());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_is_path_ignored() {
+        let (_td, repo) = graph_repo_init();
+
+        assert!(!repo.is_path_ignored(Path::new("/foo")).unwrap());
+
+        let _ = repo.add_ignore_rule("/foo");
+        assert!(repo.is_path_ignored(Path::new("\\foo\\thing")).unwrap());
+
+        let _ = repo.clear_ignore_rules();
+        assert!(!repo.is_path_ignored(Path::new("\\foo\\thing")).unwrap());
     }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2043,22 +2043,14 @@ impl Repository {
     }
 
     /// Test if the ignore rules apply to a given path.
-    #[cfg(windows)]
     pub fn is_path_ignored<P: AsRef<Path>>(&self, path: P) -> Result<bool, Error> {
-        // `git_ignore_path_is_ignored` dose not work with windows path separator
-        // so we convert \ to /
-        let path = try!(::std::ffi::CString::new(path.as_ref().to_string_lossy().replace('\\', "/")));
-        let mut ignored: c_int = 0;
-        unsafe {
-            try_call!(raw::git_ignore_path_is_ignored(&mut ignored, self.raw, path));
-        }
-        Ok(ignored == 1)
-    }
-
-    /// Test if the ignore rules apply to a given path.
-    #[cfg(not(windows))]
-    pub fn is_path_ignored<P: AsRef<Path>>(&self, path: P) -> Result<bool, Error> {
-        let path = try!(path.as_ref().into_c_string());
+        let path = if cfg!(windows) {
+            // `git_ignore_path_is_ignored` dose not work with windows path separator
+            // so we convert \ to /
+            try!(::std::ffi::CString::new(path.as_ref().to_string_lossy().replace('\\', "/")))
+        } else {
+            try!(path.as_ref().into_c_string())
+        };
         let mut ignored: c_int = 0;
         unsafe {
             try_call!(raw::git_ignore_path_is_ignored(&mut ignored, self.raw, path));
@@ -2550,22 +2542,15 @@ mod tests {
 
         let _ = repo.add_ignore_rule("/foo");
         assert!(repo.is_path_ignored(Path::new("/foo")).unwrap());
+        if cfg!(windows){
+            assert!(repo.is_path_ignored(Path::new("\\foo\\thing")).unwrap());
+        }
+
 
         let _ = repo.clear_ignore_rules();
         assert!(!repo.is_path_ignored(Path::new("/foo")).unwrap());
-    }
-
-    #[test]
-    #[cfg(windows)]
-    fn windows_is_path_ignored() {
-        let (_td, repo) = graph_repo_init();
-
-        assert!(!repo.is_path_ignored(Path::new("/foo")).unwrap());
-
-        let _ = repo.add_ignore_rule("/foo");
-        assert!(repo.is_path_ignored(Path::new("\\foo\\thing")).unwrap());
-
-        let _ = repo.clear_ignore_rules();
-        assert!(!repo.is_path_ignored(Path::new("\\foo\\thing")).unwrap());
+        if cfg!(windows){
+            assert!(!repo.is_path_ignored(Path::new("\\foo\\thing")).unwrap());
+        }
     }
 }


### PR DESCRIPTION
This is the workaround requested in #334 and therefore closes #334. When this is pushed we can proceed on https://github.com/rust-lang/cargo/pull/5733.

I wish there was a way to do this that did not involve two extra allocations. `to_string_lossy` and `replace`.