### PR TITLE
Minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ openssl-probe = { version = "0.1", optional = true }
 docopt = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-time = "0.1"
-tempdir = "0.3"
+time = "0.1.39"
+tempdir = "0.3.7"
+thread-id = "3.3.0" # remove when we work with minimal-versions without it
 
 [features]
 unstable = []

--- a/libgit2-sys/Cargo.toml
+++ b/libgit2-sys/Cargo.toml
@@ -23,7 +23,7 @@ libz-sys = "1.0.18"
 
 [build-dependencies]
 pkg-config = "0.3"
-cmake = "0.1.2"
+cmake = "0.1.24"
 cc = "1.0"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that build on modern rust. this gets libgit2-sys and git2 working with Cargos `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it [stabilized for use in CI](5657). It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them. I did not do git2-curl as there is no version of curl that works with it, so I thought I'd start there.