### PR TITLE
Make some patch functions only require &self

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -139,7 +139,7 @@ impl Patch {
     }
 
     /// Get a DiffHunk and its total line count from the Patch.
-    pub fn hunk(&mut self, hunk_idx: usize) -> Result<(DiffHunk, usize), Error> {
+    pub fn hunk(&self, hunk_idx: usize) -> Result<(DiffHunk, usize), Error> {
         let mut ret = ptr::null();
         let mut lines = 0;
         unsafe {
@@ -156,7 +156,7 @@ impl Patch {
     }
 
     /// Get a DiffLine from a hunk of the Patch.
-    pub fn line_in_hunk(&mut self,
+    pub fn line_in_hunk(&self,
                         hunk_idx: usize,
                         line_of_hunk: usize) -> Result<DiffLine, Error> {
         let mut ret = ptr::null();


### PR DESCRIPTION
I checked the documentation for libgit2 and could see no reason these two functions required `&mut self`. Without this patch it is very practically difficult to iterate through all hunks of a patch, and each line of each hunk, as they rely on the same parent `git2::Patch`.