### PR TITLE
work around for windows path separator for status_file

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -804,7 +804,13 @@ impl Repository {
     /// through looking for the path that you are interested in.
     pub fn status_file(&self, path: &Path) -> Result<Status, Error> {
         let mut ret = 0 as c_uint;
-        let path = try!(path.into_c_string());
+        let path = if cfg!(windows) {
+            // `git_status_file` dose not work with windows path separator
+            // so we convert \ to /
+            try!(::std::ffi::CString::new(path.to_string_lossy().replace('\\', "/")))
+        } else {
+            try!(path.into_c_string())
+        };
         unsafe {
             try_call!(raw::git_status_file(&mut ret, self.raw,
                                            path));

--- a/src/status.rs
+++ b/src/status.rs
@@ -400,8 +400,19 @@ mod tests {
     fn status_file() {
         let (td, repo) = ::test::repo_init();
         assert!(repo.status_file(Path::new("foo")).is_err());
+        if cfg!(windows) {
+            assert!(repo.status_file(Path::new("bar\\foo.txt")).is_err());
+        }
         t!(File::create(td.path().join("foo")));
+        if cfg!(windows) {
+            t!(::std::fs::create_dir_all(td.path().join("bar")));
+            t!(File::create(td.path().join("bar").join("foo.txt")));
+        }
         let status = t!(repo.status_file(Path::new("foo")));
         assert!(status.contains(::Status::WT_NEW));
+        if cfg!(windows) {
+            let status = t!(repo.status_file(Path::new("bar\\foo.txt")));
+            assert!(status.contains(::Status::WT_NEW));
+        }
     }
 }


### PR DESCRIPTION
part of #340. Suggested by https://github.com/rust-lang/cargo/pull/5820#issuecomment-409021860