### PR TITLE
Remove breaking nsec from android

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -68,7 +68,10 @@ fn main() {
     features.push_str("#ifndef INCLUDE_features_h\n");
     features.push_str("#define INCLUDE_features_h\n");
     features.push_str("#define GIT_THREADS 1\n");
-    features.push_str("#define GIT_USE_NSEC 1\n");
+
+    if !target.contains("android") {
+        features.push_str("#define GIT_USE_NSEC 1\n");
+    }
 
     if target.contains("apple") {
         features.push_str("#define GIT_USE_STAT_MTIMESPEC 1\n");


### PR DESCRIPTION
On Android targets the current build breaks:
```
cargo:warning=libgit2/src/iterator.c: In function 'filesystem_iterator_set_current':
cargo:warning=libgit2/src/iterator.c:1464:43: error: 'struct stat' has no member named 'st_ctim'
cargo:warning=  iter->entry.ctime.nanoseconds = entry->st.st_ctime_nsec;
cargo:warning=                                           ^
cargo:warning=libgit2/src/iterator.c:1465:43: error: 'struct stat' has no member named 'st_mtim'
cargo:warning=  iter->entry.mtime.nanoseconds = entry->st.st_mtime_nsec;
```