### PR TITLE
Add Solaris compile flags from cmake config

### DIFF
--- a/libgit2-sys/build.rs
+++ b/libgit2-sys/build.rs
@@ -69,6 +69,10 @@ fn main() {
         add_c_files(&mut cfg, "libgit2/src/unix".as_ref());
         cfg.flag("-fvisibility=hidden");
     }
+    if target.contains("solaris") {
+        cfg.define("_POSIX_C_SOURCE", "200112L");
+        cfg.define("__EXTENSIONS__", None);
+    }
 
     let mut features = String::new();
 


### PR DESCRIPTION
The removal of the cmake dependency made compilation on Solaris fail because it is missing the defines from https://github.com/libgit2/libgit2/blob/771dfd1dd1c27a4693dfdfea521c07e72f456b29/CMakeLists.txt#L199