### PR TITLE
Fix documentation for Sort::TOPOLOGICAL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,8 +377,8 @@ bitflags! {
         /// change at any time. This is the default sorting for new walkers.
         const NONE = raw::GIT_SORT_NONE as u32;
 
-        /// Sort the repository contents in topological order (parents before
-        /// children).
+        /// Sort the repository contents in topological order (children before
+        /// parents).
         ///
         /// This sorting mode can be combined with time sorting.
         const TOPOLOGICAL = raw::GIT_SORT_TOPOLOGICAL as u32;


### PR DESCRIPTION
The libgit2 documentation says "no parents before all of its children are
shown", which is exactly the opposite of what the rust docstring said.

This got me quite confused for a bit :smile: