### PR TITLE
Expose parent count on git2::Commit

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -151,14 +151,12 @@ impl<'repo> Commit<'repo> {
 
     /// Creates a new iterator over the parents of this commit.
     pub fn parents<'a>(&'a self) -> Parents<'a, 'repo> {
-        let max = unsafe { raw::git_commit_parentcount(&*self.raw) as usize };
-        Parents { range: 0..max, commit: self }
+        Parents { range: 0..self.parent_count(), commit: self }
     }
 
     /// Creates a new iterator over the parents of this commit.
     pub fn parent_ids(&self) -> ParentIds {
-        let max = unsafe { raw::git_commit_parentcount(&*self.raw) as usize };
-        ParentIds { range: 0..max, commit: self }
+        ParentIds { range: 0..self.parent_count(), commit: self }
     }
 
     /// Get the author of this commit.
@@ -208,6 +206,13 @@ impl<'repo> Commit<'repo> {
                                             tree.map(|t| t.raw())));
             Ok(Binding::from_raw(&raw as *const _))
         }
+    }
+
+    /// Get the number of parents of this commit.
+    ///
+    /// Use the `parents` iterator to return an iterator over all parents.
+    pub fn parent_count(&self) -> usize {
+        unsafe { raw::git_commit_parentcount(&*self.raw) as usize }
     }
 
     /// Get the specified parent of the commit.


### PR DESCRIPTION
Currently there's no great way to get the number of parent commits, despite that info being available as `commit.parents().size_hint().0`, which is pretty sketchy :-). This should make it easier to detect commits which don't have exactly 1 parent efficiently.

I think a cleaner solution here would be to make `git2::Parents` and `git2::ParentIds` be slice-like view objects (implementing `Index<usize>`, `fn len(&self) -> usize`, `IntoIterator`, etc.), and having a separate object for the actual iterator, but this would not be 100% backwards-compatible (as the return value from `parents` would not itself be an iterator), so I did not take this approach.