### PR TITLE
Expose openssl vendored feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ default = ["ssh", "https", "curl", "ssh_key_from_memory"]
 ssh = ["libgit2-sys/ssh"]
 https = ["libgit2-sys/https", "openssl-sys", "openssl-probe"]
 curl = ["libgit2-sys/curl"]
+vendored-openssl = ["openssl-sys/vendored"]
 ssh_key_from_memory = ["libgit2-sys/ssh_key_from_memory"]
 
 [workspace]


### PR DESCRIPTION
I'm developing on arch and deploying to ubuntu and get this error when I run the binary.
```
./pf_sandbox_website: /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1: version `OPENSSL_1_1_1' not found (required by ./pf_sandbox_website)
```
I was able to resolve the issue by statically linking as per this PR.


Is exposing it like this the correct solution?
What about `libgit2-sys`? I didn't need to change anything in its `cargo.toml` even though it uses `openssl-sys` as well.